### PR TITLE
Fix /e modified deprecated errors.

### DIFF
--- a/components/com_joomgallery/helpers/helper.php
+++ b/components/com_joomgallery/helpers/helper.php
@@ -252,7 +252,9 @@ class JoomHelper
       $replace  = trim($replace);
       $replace2 = str_replace('[!', '\[\!', $results[0][$i]);
       $replace2 = str_replace('!]', '\!\]', $replace2);
-      $text     = preg_replace('/('.$replace2.')/ie', $replace, $text);
+      $text     = preg_replace_callback('/('.$replace2.')/i', function($matches) use ($replace){
+        return JText::_($replace);
+      }, $text);
     }
     $text = str_replace('#cat', $catname, $text);
     $text = str_replace('#img', $imgtitle, $text);


### PR DESCRIPTION
Since PHP 5.5 `/e` modifier is deprecated for `preg_replace`. See [preg_replace changelog](http://php.net/manual/en/function.preg-replace.php#refsect1-function.preg-replace-changelog).
Using `preg_replace_callback` instead.