### PR TITLE
Improving performance of Maintenancemanager by adding an index

### DIFF
--- a/administrator/components/com_joomgallery/sql/install.mysql.utf8.sql
+++ b/administrator/components/com_joomgallery/sql/install.mysql.utf8.sql
@@ -431,7 +431,8 @@ CREATE TABLE IF NOT EXISTS `#__joomgallery_orphans` (
   `type` varchar(7) NOT NULL,
   `refid` int(11) NOT NULL,
   `title` text NOT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `fullpath` (`fullpath`(255))
 ) DEFAULT CHARSET=utf8;
 
 CREATE TABLE IF NOT EXISTS `#__joomgallery_users` (

--- a/administrator/components/com_joomgallery/sql/updates/mysql/3.2.1.sql
+++ b/administrator/components/com_joomgallery/sql/updates/mysql/3.2.1.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `#__joomgallery_orphans`
+	ADD INDEX `fullpath` (`fullpath`);


### PR DESCRIPTION
This adds an index to the fullpath column of the orphans table, which extremely improves the performance of the maintenance manager. Especially in very large galleries, the database takes an extremely long time to scan the fullpath column for each query. The performance improved ~2000% for a gallery with 30k images.

Ref.: http://www.forum.joomgallery.net/index.php/topic,6190.0.html