### PR TITLE
Clean table #__modules_menu on component uninstall

### DIFF
--- a/administrator/components/com_joomgallery/sql/uninstall.mysql.utf8.sql
+++ b/administrator/components/com_joomgallery/sql/uninstall.mysql.utf8.sql
@@ -34,4 +34,5 @@ DROP TABLE `#__joomgallery_maintenance`;
 DELETE FROM `#__joomgallery_orphans`;
 DROP TABLE `#__joomgallery_orphans`;
 
-DELETE FROM #__modules WHERE position = 'joom_cpanel';
+DELETE FROM `#__modules_menu` WHERE `moduleid` IN (SELECT id FROM `#__modules` WHERE `position` = 'joom_cpanel');
+DELETE FROM `#__modules` WHERE `position` = 'joom_cpanel';


### PR DESCRIPTION
When uninstalling JoomGallery the table #__modules_menu still contains an entry created by the JoomGallery installation process. This pull request corrects that.
