### PR TITLE
Use Bootstrap styled buttons in detail view

### DIFF
--- a/components/com_joomgallery/views/detail/tmpl/default.php
+++ b/components/com_joomgallery/views/detail/tmpl/default.php
@@ -445,7 +445,7 @@ echo $this->loadTemplate('header'); ?>
         <?php echo $this->voting; ?>
         <?php echo JText::_('COM_JOOMGALLERY_DETAIL_RATING_GOOD', $this->maxvoting); ?>
         <p>
-          <input class="button" type="submit" value="<?php echo JText::_('COM_JOOMGALLERY_DETAIL_RATING_VOTE'); ?>" name="<?php echo JText::_('COM_JOOMGALLERY_DETAIL_RATING_VOTE'); ?>" />
+          <input class="btn btn-small btn-primary" type="submit" value="<?php echo JText::_('COM_JOOMGALLERY_DETAIL_RATING_VOTE'); ?>" name="<?php echo JText::_('COM_JOOMGALLERY_DETAIL_RATING_VOTE'); ?>" />
         </p>
       </form>
 <?php     endif;
@@ -537,7 +537,7 @@ echo $this->loadTemplate('header'); ?>
         <div class="jg_cmtl">
           <?php echo $this->_user->get('username'); ?>
 <?php     if(!$this->_user->get('id') && $this->_config->get('jg_namedanoncomment')): ?>
-          <input title="<?php echo JText::_('COM_JOOMGALLERY_COMMON_GUEST'); ?>" type="text" class="inputbox" name="cmtname" value="<?php echo $this->_mainframe->getUserState('joom.comments.name', JText::_('COM_JOOMGALLERY_COMMON_GUEST')); ?>" tabindex="1" />
+          <input title="<?php echo JText::_('COM_JOOMGALLERY_COMMON_GUEST'); ?>" type="text" class="inputbox input-medium" name="cmtname" value="<?php echo $this->_mainframe->getUserState('joom.comments.name', JText::_('COM_JOOMGALLERY_COMMON_GUEST')); ?>" tabindex="1" />
 <?php     endif;
           if($this->params->get('smiley_support')): ?>
           <div class="jg_cmtsmilies">
@@ -570,9 +570,9 @@ echo $this->loadTemplate('header'); ?>
           &nbsp;
         </div>
         <div class="jg_cmtr">
-          <input type="button" name="send" value="<?php echo JText::_('COM_JOOMGALLERY_DETAIL_COMMENTS_SEND_COMMENT'); ?>" class="button" onclick="joom_validatecomment()" />
+          <input type="button" name="send" value="<?php echo JText::_('COM_JOOMGALLERY_DETAIL_COMMENTS_SEND_COMMENT'); ?>" class="btn btn-primary btn-small" onclick="joom_validatecomment()" />
             &nbsp;
-          <input type="reset" value="<?php echo JText::_('COM_JOOMGALLERY_COMMON_DELETE'); ?>" name="reset" class="button" />
+          <input type="reset" value="<?php echo JText::_('COM_JOOMGALLERY_COMMON_DELETE'); ?>" name="reset" class="btn btn-small" />
         </div>
       </form>
 <?php   endif;
@@ -619,7 +619,7 @@ echo $this->loadTemplate('header'); ?>
           &nbsp;
         </div>
         <p class="jg_s2fr">
-          <input type="button" name="send" value="<?php echo JText::_('COM_JOOMGALLERY_DETAIL_SENDTOFRIEND_SEND_EMAIL'); ?>" class="button" onclick="joom_validatesend2friend()" />
+          <input type="button" name="send" value="<?php echo JText::_('COM_JOOMGALLERY_DETAIL_SENDTOFRIEND_SEND_EMAIL'); ?>" class="btn btn-primary btn-small" onclick="joom_validatesend2friend()" />
         </p>
       </form>
 <?php   endif;

--- a/media/joomgallery/css/joomgallery.css
+++ b/media/joomgallery/css/joomgallery.css
@@ -272,6 +272,7 @@ div.jg_voting form{
   vertical-align:top;
 }
 .jg_s2fl{
+  clear:left;
   float:left;
   width:23%;
   text-align:left !important;

--- a/media/joomgallery/css/joomgallery_rtl.css
+++ b/media/joomgallery/css/joomgallery_rtl.css
@@ -69,6 +69,7 @@ div.jg_photo_left, div.jg_bbcode_left, div.jg_exif_left,div.jg_cmtl {
   text-align:right;
 }
 .jg_s2fl{
+  clear:right;
   float:right;
   text-align:right !important;
 }


### PR DESCRIPTION
This pull request changes the styling of the input buttons in the rating, comments and send to friend section of the detail view by using the Bootstrap button classes.

Some little tweaks to the CSS are also done in the send to friend section (adding a floating clear) and the size of the input text for named anonymous comments in the comment section.
