### PR TITLE
Use Bootstrap button and modal in Joomuser form field

### DIFF
--- a/administrator/components/com_joomgallery/models/fields/joomuser.php
+++ b/administrator/components/com_joomgallery/models/fields/joomuser.php
@@ -11,7 +11,7 @@
 **   at administrator/components/com_joomgallery/LICENSE.TXT                            **
 \****************************************************************************************/
 
-defined('_JEXEC') or die( 'Restricted access' );
+defined('_JEXEC') or die('Restricted access');
 
 jimport('joomla.form.formfield');
 jimport('joomla.form.helper');
@@ -45,42 +45,73 @@ class JFormFieldJoomUser extends JFormFieldUser
     $html     = array();
     $groups   = $this->getGroups();
     $excluded = $this->getExcluded();
-    $link     = 'index.php?option=com_users&amp;view=users&amp;layout=modal&amp;tmpl=component&amp;field='.$this->id.(isset($groups) ? ('&amp;groups='.base64_encode(json_encode($groups))) : '').(isset($excluded) ? ('&amp;excluded='.base64_encode(json_encode($excluded))) : '');
+    $link     = 'index.php?option=com_users&amp;view=users&amp;layout=modal&amp;tmpl=component&amp;field=' . $this->id
+                  . (isset($groups) ? ('&amp;groups='.base64_encode(json_encode($groups))) : '')
+                  . (isset($excluded) ? ('&amp;excluded='.base64_encode(json_encode($excluded))) : '');
+    $required = '';
 
-    // Initialize some field attributes.
-    $attr  = $this->element['class'] ? ' class="'.(string) $this->element['class'].'"' : '';
-    $attr .= $this->element['size'] ? ' size="'.(int) $this->element['size'].'"' : '';
+    if($this->required)
+    {
+      $required = ' required';
 
-    // Initialize JavaScript field attributes.
-    $onchange = (string) $this->element['onchange'];
+      if(!empty($this->class))
+      {
+        $this->class .= ' ';
+      }
+      $this->class .= 'validate-SelectUser_' . $this->id;
+    }
 
-    // Load the modal behavior script.
-    JHtml::_('behavior.modal', 'a.modal_'.$this->id);
+    $attr = !empty($this->class) ? ' class="' . $this->class . '"' : '';
+    $attr .= !empty($this->size) ? ' size="' . $this->size . '"' : '';
+    $attr .= $this->required ? ' required' : '';
+
+    JHtml::_('bootstrap.tooltip');
 
     // Build the script.
     $script   = array();
-    $script[] = ' function jSelectUser_'.$this->id.'(id, title) {';
-    $script[] = '   var old_id = document.getElementById("'.$this->id.'_id").value;';
-    $script[] = '   if (old_id != id) {';
-    $script[] = '     document.getElementById("'.$this->id.'_id").value = id;';
-    $script[] = '     if (id == "") {';
-    $script[] = '       document.getElementById("'.$this->id.'_name").value = "'.JText::_('COM_JOOMGALLERY_COMMON_NO_USER', true).'";';
-    $script[] = '     }';
-    $script[] = '     else {';
-    $script[] = '       document.getElementById("'.$this->id.'_name").value = title;';
-    $script[] = '     }';
-    $script[] = '     '.$onchange;
-    $script[] = '   }';
-    $script[] = '   SqueezeBox.close();';
-    $script[] = ' }';
+
+    if ($this->required)
+    {
+      $script[] = '  jQuery(document).ready(function() {';
+      $script[] = '    document.formvalidator.setHandler("SelectUser_' . $this->id . '", function(value) {';
+      $script[] = '      if (value == "" || value == "' . JText::_('COM_JOOMGALLERY_COMMON_NO_USER') . '") {';
+      $script[] = '        return false;';
+      $script[] = '      }';
+      $script[] = '      return true;';
+      $script[] = '    })';
+      $script[] = '  });';
+    }
+
+    $script[] = '  function jSelectUser_' . $this->id . '(id, title) {';
+    $script[] = '    var old_id = document.getElementById("' . $this->id . '").value;';
+    $script[] = '    if (old_id != id) {';
+    $script[] = '      document.getElementById("' . $this->id . '").value = id;';
+    $script[] = '      if (id == "") {';
+    $script[] = '        document.getElementById("' . $this->id . '_name").value = "' . JText::_('COM_JOOMGALLERY_COMMON_NO_USER', true) . '";';
+    $script[] = '      }';
+    $script[] = '      else {';
+    $script[] = '        document.getElementById("' . $this->id . '_name").value = title;';
+    $script[] = '      }';
+    $script[] = '      ' . $this->onchange;
+
+    if ($this->required)
+    {
+      $script[] = '      document.formvalidator.validate(document.getElementById("' . $this->id . '"));';
+      $script[] = '      document.formvalidator.validate(document.getElementById("' . $this->id . '_name"));';
+    }
+
+    $script[] = '    }';
+    $script[] = '    jQuery("#modalJoomuser").modal("hide");';
+    $script[] = '  }';
 
     // Add the script to the document head.
     JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 
-    // Load the current user if available.
+    // Load the current user name if available.
     $config = JoomConfig::getInstance();
     $type   = $config->get('jg_realname') ? 'name' : 'username';
     $table  = JTable::getInstance('user');
+
     if($this->value)
     {
       $table->load($this->value);
@@ -88,30 +119,37 @@ class JFormFieldJoomUser extends JFormFieldUser
     else
     {
       $table->$type = JText::_('COM_JOOMGALLERY_COMMON_NO_USER');
+      $this->value = '';
     }
 
     // Create a dummy text field with the user name.
-    $html[] = '<div class="fltlft">';
-    $html[] = ' <input type="text" id="'.$this->id.'_name"' .
-          ' value="'.htmlspecialchars($table->$type, ENT_COMPAT, 'UTF-8').'"' .
-          ' disabled="disabled"'.$attr.' />';
-    $html[] = '</div>';
+    $html[] = '<div class="input-append">';
+    $html[] = '  <input type="text" id="' . $this->id . '_name"' . ' value="' . htmlspecialchars($table->$type, ENT_COMPAT, 'UTF-8')
+                . '"' . ' readonly' . $attr . ' />';
 
     // Create the user select button.
-    $html[] = '<div class="button2-left">';
-    $html[] = '  <div class="blank">';
-    if($this->element['readonly'] != 'true')
+    if ($this->readonly === false)
     {
-      $html[] = '   <a class="modal_'.$this->id.'" title="'.JText::_('JLIB_FORM_CHANGE_USER').'"' .
-              ' href="'.$link.'"' .
-              ' rel="{handler: \'iframe\', size: {x: 800, y: 500}}">';
-      $html[] = '     '.JText::_('JLIB_FORM_CHANGE_USER').'</a>';
+      $html[] = '<a href="#modalJoomuser" class="btn hasTooltip" role="button" data-toggle="modal"'
+                  . ' title="' . JHtml::tooltipText('JLIB_FORM_CHANGE_USER') . '">'
+                  . '<i class="icon-user"></i></a>';
+
+      $html[] = JHtmlBootstrap::renderModal(
+                  'modalJoomuser', array(
+                    'url' => $link . '&amp;' . JSession::getFormToken() . '=1"',
+                    'title' => JText::_('JLIB_FORM_CHANGE_USER'),
+                    'width' => '800px',
+                    'height' => '300px',
+                    'footer' => '<button class="btn" data-dismiss="modal" aria-hidden="true">'
+                                  . JText::_("JLIB_HTML_BEHAVIOR_CLOSE") . '</button>'
+                  )
+                );
     }
-    $html[] = '  </div>';
+
     $html[] = '</div>';
 
-    // Create the real field, hidden, that stored the user id.
-    $html[] = '<input type="hidden" id="'.$this->id.'_id" name="'.$this->name.'" value="'.(int) $this->value.'" />';
+    // Create the real field, hidden, that stores the user id.
+    $html[] = '<input type="hidden" id="' . $this->id . '" name="' . $this->name . '" value="' . $this->value . '"' . $required . ' />';
 
     return implode("\n", $html);
   }


### PR DESCRIPTION
The Joomuser form field is used in different backend views to assign an owner to a category or an image.

This pull request changes the simple text link (Select user) to open the modal user selection into a nice Bootstrap button and makes use of the Bootstrap modal box instead of the Mootools one.
#### Test instructions

To test this pull request just edit a category (or an image) in the backend and assign an owner to it. Check if everything is working like before.
