### PR TITLE
Remove 'nowrap' from CSS class 'jg_catorderlist'

### DIFF
--- a/media/joomgallery/css/joomgallery.css
+++ b/media/joomgallery/css/joomgallery.css
@@ -460,7 +460,6 @@ div.limit, div.counter {
   padding:5px;
 }
 .jg_catorderlist{
-  white-space:nowrap;
   text-align:right;
 }
 


### PR DESCRIPTION
The setting prevents proper wrapping of the sort order fields in category view for small displays, so this pull request wants to remove it.
