### PR TITLE
Exchange Mootools tooltips with Bootstrap tooltips

### DIFF
--- a/administrator/components/com_joomgallery/helpers/html/joomgallery.php
+++ b/administrator/components/com_joomgallery/helpers/html/joomgallery.php
@@ -318,26 +318,34 @@ abstract class JHtmlJoomGallery
         $params = array();
         if($config->get('jg_tooltips') == 2)
         {
-          $params['className'] = 'jg-tooltip-wrap';
+          $params['template']  = '<div class="jg-tooltip-wrap tooltip"><div class="tooltip-inner tip"></div></div>';
         }
 
-        JHTML::_('behavior.tooltip', '.'.$class, $params);
+        JHtml::_('bootstrap.tooltip', '.'.$class, $params);
         $loaded = true;
       }
 
-      if($translate)
+      if($config->get('jg_tooltips') == 2)
       {
-        $text = JText::_($text);
-      }
-
-      if($title)
-      {
-        if($translate)
+        $tmp = "";
+        if($title)
         {
-          $title = JText::_($title);
+          $tmp = '<div class="tip-title">';
+
+          if($translate)
+          {
+            $title = JText::_($title);
+          }
+
+          $tmp .= $title . '</div>';
         }
 
-        $text = $title.'::'.$text;
+        $tmp .= '<div class="tip-text">' . ($translate ? JText::_($text) : $text) . '</div>';
+        $text = htmlspecialchars($tmp, ENT_QUOTES, 'UTF-8');
+      }
+      else
+      {
+        $text = JHtml::tooltipText($title, $text, $translate);
       }
 
       if($addclass)
@@ -1254,7 +1262,7 @@ abstract class JHtmlJoomGallery
       {
         if($isSite)
         {
-          $html .= '<span'.JHtml::_('joomgallery.tip', htmlspecialchars('<img src="'.$url.'" width="'.$imginfo[0].'" height="'.$imginfo[1].'" alt="'.$img->imgtitle.'" />', ENT_QUOTES, 'UTF-8'), null, true, false).'>';
+          $html .= '<span'.JHtml::_('joomgallery.tip', '<img src="'.$url.'" width="'.$imginfo[0].'" height="'.$imginfo[1].'" alt="'.$img->imgtitle.'" />', null, true, false).'>';
         }
         else
         {
@@ -1337,7 +1345,7 @@ abstract class JHtmlJoomGallery
         {
           if($isSite)
           {
-            $html .= '<span'.JHtml::_('joomgallery.tip', htmlspecialchars('<img src="'.$url.'" width="'.$imginfo[0].'" height="'.$imginfo[1].'" alt="'.$cat->name.'" />', ENT_QUOTES, 'UTF-8'), null, true, false).'>';
+            $html .= '<span'.JHtml::_('joomgallery.tip', '<img src="'.$url.'" width="'.$imginfo[0].'" height="'.$imginfo[1].'" alt="'.$cat->name.'" />', null, true, false).'>';
           }
           else
           {

--- a/administrator/components/com_joomgallery/views/mini/tmpl/default_minis.php
+++ b/administrator/components/com_joomgallery/views/mini/tmpl/default_minis.php
@@ -7,7 +7,7 @@
       foreach($this->images as $row): ?>
     <div class="jg_bu_mini">
 <?php if($row->thumb_src): ?>
-      <a href="javascript:if(typeof window.parent.<?php echo $this->prefix; ?>_selectimage == 'function'){window.parent.<?php echo $this->prefix; ?>_selectimage(<?php echo $row->id; ?>, '<?php echo str_replace("'", "\'", $this->escape(stripslashes($row->imgtitle))); ?>', '<?php echo $this->object; ?>', '<?php echo $row->imgthumbname; ?>');}else{insertJoomPluWithId('<?php echo $row->id; ?>', '<?php echo $this->e_name; ?>');}" rel="<?php echo $row->overlib; ?>" class="hasMiniTip">
+      <a href="javascript:if(typeof window.parent.<?php echo $this->prefix; ?>_selectimage == 'function'){window.parent.<?php echo $this->prefix; ?>_selectimage(<?php echo $row->id; ?>, '<?php echo str_replace("'", "\'", $this->escape(stripslashes($row->imgtitle))); ?>', '<?php echo $this->object; ?>', '<?php echo $row->imgthumbname; ?>');}else{insertJoomPluWithId('<?php echo $row->id; ?>', '<?php echo $this->e_name; ?>');}" title="<?php echo $row->overlib; ?>" class="hasMiniTip">
         <img src="<?php echo $row->thumb_src; ?>" border="0" height="40" width="40" alt="Thumbnail" /></a>
 <?php endif;
       if(!$row->thumb_src): ?>

--- a/media/joomgallery/css/joomgallery.css
+++ b/media/joomgallery/css/joomgallery.css
@@ -136,10 +136,17 @@ img.jg_icon{
 /* Tooltip-Styles */
 .jg-tooltip-wrap .tip {
   background:#C64934;
-  width:250px;
+  max-width:250px;
   padding:1px;
   border:none;
   text-align:left;
+  -webkit-border-radius: 0px;
+  -moz-border-radius: 0px;
+  border-radius: 0px;  
+}
+.jg-tooltip-wrap.tooltip.in {
+  opacity: 1;
+  filter: alpha(opacity=100);
 }
 .jg-tooltip-wrap .tip-title {
   font-family:Verdana,Arial,Helvetica,sans-serif;

--- a/media/joomgallery/js/detail.js
+++ b/media/joomgallery/js/detail.js
@@ -199,27 +199,13 @@ function joomAjaxVoteResponse(response)
     // Refresh rating tooltip
     if(response.data.tooltipclass != null)
     {
-      $$('.hasHintAjaxVote').each(function(el) {
-        var title = el.get('title');
-        if(title) {
-          var parts = title.split('::', 2);
-          el.store('tip:title', parts[0]);
-          el.store('tip:text', parts[1]);
-        }
-      });
-
       if(response.data.tooltipclass == 'default')
       {
-        var tooltips = new Tips($$('.hasHintAjaxVote'), { maxTitleChars: 50,
-                                                          fixed: false
-                                                        });
+        jQuery('.hasHintAjaxVote').tooltip();
       }
       else
       {
-        var tooltips = new Tips($$('.hasHintAjaxVote'), { maxTitleChars: 50,
-                                                          fixed: false,
-                                                          className: response.data.tooltipclass
-                                                        });
+        jQuery('.hasHintAjaxVote').tooltip({template: '<div class="jg-tooltip-wrap tooltip"><div class="tooltip-inner tip"></div></div>'});        
       }
     }
   }

--- a/media/joomgallery/js/mini.js
+++ b/media/joomgallery/js/mini.js
@@ -302,7 +302,7 @@ function ajaxRequest(url, page, query)
                 $('jg_bu_pagelinks').set('html', response.pagination);
 
                 // Now we have to create the tooltips for all the new images
-                var JTooltips = new Tips($$('.hasMiniTip'), { maxTitleChars: 50, fixed: false});
+                jQuery('.hasMiniTip').tooltip({container: 'body'});
 
                 // Set current page if it was changed
                 if(page > 0)
@@ -589,25 +589,9 @@ function displayInsertOptions(uploader, item, fileName, r)
 // Preparations
 window.addEvent('domready', function()
 {
-  $$('.hasTooltip').each(function(el) {
-    var title = el.get('title');
-    if (title) {
-      var parts = title.split('::', 2);
-      el.store('tip:title', parts[0]);
-      el.store('tip:text', parts[1]);
-    }
-  });
-  var JTooltips = new Tips($$('.hasTooltip'), {maxTitleChars: 50, fixed: false});
+  jQuery('.hasTooltip').tooltip({container: 'body'});
 
-  $$('.hasMiniTip').each(function(el) {
-    var title = el.get('title');
-    if (title) {
-      var parts = title.split('::', 2);
-      el.store('tip:title', parts[0]);
-      el.store('tip:text', parts[1]);
-    }
-  });
-  var JTooltips = new Tips($$('.hasMiniTip'), {maxTitleChars: 50, fixed: false});
+  jQuery('.hasMiniTip').tooltip({container: 'body'});
 
   document.formvalidator.setHandler('joompositivenumeric', function(value) {
     regex=/^[1-9]+[0-9]*$/;


### PR DESCRIPTION
This pull request removes the use of Mootools tooltips in frontend and backend by using the Bootstrap equivalent.
#### Test instructions

Check, whether frontend and backend tooltips work like before. Also change the tooltip styling in JoomGallery's configuration manager and check.

When working on this pull request I found out, that when using `Different styling` or `Disabled` for the tooltip styling there will still display some tooltips in `Default styling`. I think, with the introduction of Bootsstrap in Joomla! and JoomGallery this option was neglected.

In my opinion the tooltip styling is a template thing and should be the same for all extensions in one Joomla! installation. Therefore I would propose to remove this JoomGallery option with JoomGallery 4.0.
