### PR TITLE
Fix close button not always displaying in DHTML box

### DIFF
--- a/administrator/components/com_joomgallery/helpers/html/joomgallery.php
+++ b/administrator/components/com_joomgallery/helpers/html/joomgallery.php
@@ -613,7 +613,7 @@ abstract class JHtmlJoomGallery
         {
           $link .= "','";
         }
-        $link .= $imginfo[0]."','".$imginfo[1]."')";
+        $link .= $imginfo[0]."','".$imginfo[1]."','".JUri::root()."')";
 
         if(!isset($loaded[3]))
         {

--- a/media/joomgallery/js/dhtml.js
+++ b/media/joomgallery/js/dhtml.js
@@ -14,7 +14,7 @@
 // modified by JoomGallery team
 // The DHTML-function for creating a overlaying div-layer uses parts of the Dynamic Image Mambot, written by Manuel Hirsch
 // and Lightbox => core code quirksmode.org
-function joom_opendhtml(imgsource, imgtitle, imgtext, imgwidth, imgheight)
+function joom_opendhtml(imgsource, imgtitle, imgtext, imgwidth, imgheight, baseURL)
 {
   imgwidth = parseInt(imgwidth);
   imgheight = parseInt(imgheight);
@@ -91,7 +91,7 @@ function joom_opendhtml(imgsource, imgtitle, imgtext, imgwidth, imgheight)
   }
 
   var closeimg  = new Image();
-  closeimg.src  = "media/joomgallery/images/close.png";
+  closeimg.src  = baseURL + "media/joomgallery/images/close.png";
   var closeimgw = "";
   var closeimgh = "";
   if(closeimg.complete == true)


### PR DESCRIPTION
This pull request fixes the problem, that the PNG for the close button of the DHTML box does not have the correct path for all cases and therefore can't be loaded by the browser.
