### PR TITLE
Fix filename validation in drag'n'drop upload

### DIFF
--- a/administrator/components/com_joomgallery/models/fields/fineuploader.php
+++ b/administrator/components/com_joomgallery/models/fields/fineuploader.php
@@ -177,7 +177,7 @@ class JFormFieldFineuploader extends JFormField
         onValidate: function(fileData) {
           if(!jg_filenamewithjs) {
             var searchwrongchars = /[^a-zA-Z0-9_-]/;
-            if(searchwrongchars.test(fileData.name)) {
+            if(searchwrongchars.test(fileData.name.substr(0, fileData.name.lastIndexOf('.')))) {
               this._itemError('fileNameError', fileData.name);
               return false;
             }


### PR DESCRIPTION
If the JoomGallery configuration option **Allow special characters in filenames for uploads** is set to **No** an error is always shown that the file contains invalid characters although it does not.

This is due to the fact that the check to the filename is done including the extension and the dot is an invalid character. This pull request should fix that.      
