### PR TITLE
Fix filtering in user panel view

### DIFF
--- a/components/com_joomgallery/views/userpanel/tmpl/default.php
+++ b/components/com_joomgallery/views/userpanel/tmpl/default.php
@@ -56,7 +56,7 @@ echo $this->loadTemplate('header');
         </div>
         <div class="btn-group pull-left hidden-phone">
           <button class="btn hasTooltip" type="submit" title="<?php echo JText::_('COM_JOOMGALLERY_COMMON_FILTER_SEARCH'); ?>"><i class="icon-search"></i></button>
-          <button class="btn hasTooltip" type="button" onclick="document.id('filter_search').value='';this.form.submit();" title="<?php echo JText::_('JSEARCH_FILTER_CLEAR'); ?>"><i class="icon-remove"></i></button>
+          <button class="btn hasTooltip" type="button" onclick="document.getElementById('filter_search').value='';this.form.submit();" title="<?php echo JText::_('JSEARCH_FILTER_CLEAR'); ?>"><i class="icon-remove"></i></button>
         </div>
         <div class="btn-group pull-right hidden-phone">
           <label for="limit" class="element-invisible"><?php echo JText::_('COM_JOOMGALLERY_COMMON_SEARCH_LIMIT'); ?></label>
@@ -84,7 +84,7 @@ echo $this->loadTemplate('header');
           <?php echo $this->lists['filter_state']; ?>
         </div>
         <div class="btn-group pull-right hidden-phone">
-          <?php echo JHtml::_('joomselect.categorylist', $this->state->get('filter.category'), 'filter_category', 'onchange="document.id(\'adminForm\').submit()"', null, '- ', 'filter'); ?>
+          <?php echo JHtml::_('joomselect.categorylist', $this->state->get('filter.category'), 'filter_category', 'onchange="document.adminForm.submit();"', null, '- ', 'filter'); ?>
         </div>
       </div>
       <div class="clearfix"> </div>


### PR DESCRIPTION
Filtering by category and clearing the search in the user panel view is not possible since #31 has been implemented. Mootools is not loaded any longer so that the use of `document.id` leads to a javascript error. This pull request should fix that.
