### PR TITLE
Fix filtering in user categories view

### DIFF
--- a/components/com_joomgallery/views/usercategories/tmpl/default.php
+++ b/components/com_joomgallery/views/usercategories/tmpl/default.php
@@ -59,7 +59,7 @@ $sortFields = $this->getSortFields();
         </div>
         <div class="btn-group pull-left hidden-phone">
           <button class="btn hasTooltip" type="submit" title="<?php echo JText::_('COM_JOOMGALLERY_COMMON_FILTER_SEARCH'); ?>"><i class="icon-search"></i></button>
-          <button class="btn hasTooltip" type="button" onclick="document.id('filter_search').value='';this.form.submit();" title="<?php echo JText::_('JSEARCH_FILTER_CLEAR'); ?>"><i class="icon-remove"></i></button>
+          <button class="btn hasTooltip" type="button" onclick="document.getElementById('filter_search').value='';this.form.submit();" title="<?php echo JText::_('JSEARCH_FILTER_CLEAR'); ?>"><i class="icon-remove"></i></button>
         </div>
         <div class="btn-group pull-right hidden-phone">
           <label for="limit" class="element-invisible"><?php echo JText::_('COM_JOOMGALLERY_COMMON_SEARCH_LIMIT'); ?></label>


### PR DESCRIPTION
Clearing the search in the user categories view is not possible since #31 has been implemented. Mootools is not loaded any longer so that the use of `document.id` leads to a javascript error. This pull request should fix that.
