### PR TITLE
Fix concealed buttons in the reject popup of the back end images view

### DIFF
--- a/administrator/components/com_joomgallery/views/images/tmpl/default_reject.php
+++ b/administrator/components/com_joomgallery/views/images/tmpl/default_reject.php
@@ -1,4 +1,6 @@
-<?php defined('_JEXEC') or die('Direct Access to this location is not allowed.'); ?>
+<?php defined('_JEXEC') or die('Direct Access to this location is not allowed.');
+JHtml::_('bootstrap.tooltip', '.modalTooltip', array('container' => '.modal-body'));
+?>
 <div class="modal hide fade" tabindex="-1" role="dialog" aria-labelledby="PopupRejectModalLabel" aria-hidden="true" id="jg-reject-popup">
   <script type="text/javascript">
     jQuery('#jg-reject-popup').on('shown', function ()
@@ -12,21 +14,24 @@
       <h3 id="PopupRejectModalLabel"><?php echo JText::_('COM_JOOMGALLERY_IMGMAN_REJECT_IMAGE_HEADING'); ?></h3>
     </div>
     <div class="modal-body">
-      <div class="pull-right span6">
-        <img src="../media/system/images/blank.png" class="img-polaroid span12" id="jg-reject-image" alt="Thumbnail" />
-      </div>
-      <p id="jg-reject-no-owner"><?php echo JText::_('COM_JOOMGALLERY_IMGMAN_REJECT_IMAGE_NOOWNER'); ?></p>
-      <div id="jg-reject-owner">
-        <p><?php echo JText::sprintf('COM_JOOMGALLERY_IMGMAN_REJECT_IMAGE_OWNER', '<span id="jg-reject-owner-name"></span>'); ?></p>
-        <div class="clearfix"></div>
-        <div class="control-group">
-          <div class="control-label span6">
-            <label rel="tooltip" class="spn6" title="<?php echo JText::_('COM_JOOMGALLERY_IMGMAN_REJECT_IMAGE_MESSAGE_TIP'); ?>">
-              <?php echo JText::_('COM_JOOMGALLERY_IMGMAN_REJECT_IMAGE_MESSAGE_LABEL'); ?>
-            </label>
-          </div>
-          <div class="controls">
-            <textarea id="jg-message" name="message" class="span12" cols="30" rows="7"></textarea>
+      <div class="row-fluid">
+        <div class="span4">
+          <img src="../media/system/images/blank.png" class="img-polaroid" id="jg-reject-image" alt="Thumbnail" />
+        </div>
+        <div class="span8">
+          <p id="jg-reject-no-owner"><?php echo JText::_('COM_JOOMGALLERY_IMGMAN_REJECT_IMAGE_NOOWNER'); ?></p>
+          <div id="jg-reject-owner">
+            <p><?php echo JText::sprintf('COM_JOOMGALLERY_IMGMAN_REJECT_IMAGE_OWNER', '<span id="jg-reject-owner-name"></span>'); ?></p>
+            <div class="control-group">
+              <div class="control-label">
+                <label for="jg-message" class="modalTooltip" title="<?php echo JText::_('COM_JOOMGALLERY_IMGMAN_REJECT_IMAGE_MESSAGE_TIP'); ?>">
+                  <?php echo JText::_('COM_JOOMGALLERY_IMGMAN_REJECT_IMAGE_MESSAGE_LABEL'); ?>
+                </label>
+              </div>
+              <div class="controls">
+                <textarea id="jg-message" name="message" cols="30" rows="6" class="span12"></textarea>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/media/joomgallery/css/admin.joomgallery.css
+++ b/media/joomgallery/css/admin.joomgallery.css
@@ -62,11 +62,11 @@
   margin:5px 0px;
 }
 .jg_updexistautoform form {
-	margin: 0;
+  margin: 0;
 }
 .jg_updexistversion table{
   margin-bottom: 9px;
-}	
+}  
 
 /* MiniJoom */
 .jg_bu_filter{
@@ -165,7 +165,7 @@ label#rules-lbl {
 }
 
 .jg_imgpreview{
-	max-width:500px;
+  max-width:500px;
 }
 
 /* Ajax Category Search */
@@ -184,11 +184,11 @@ label#rules-lbl {
   padding:5px;
 }
 .jg-category-result:hover{
-	background-color:#e8f6fe;
-	cursor:pointer;
+  background-color:#e8f6fe;
+  cursor:pointer;
 }
 .jg-category-result-hover{
-	background-color:#e8f6fe !important;
+  background-color:#e8f6fe !important;
 }
 
 .categories-results{
@@ -198,11 +198,11 @@ label#rules-lbl {
 }
 
 .row0{
-	background-color:#f7f7f7;
+  background-color:#f7f7f7;
 }
 .row1{
-	background-color:#f0f0f0;
-	border-top:1px solid #ffffff;
+  background-color:#f0f0f0;
+  border-top:1px solid #ffffff;
 }
 .jg-no-results{
   padding:5px;
@@ -214,8 +214,8 @@ label#rules-lbl {
   border-bottom:1px solid grey;
 }
 .jg-category-more-results:hover{
-	background-color:#e8f6fe;
-	cursor:pointer;
+  background-color:#e8f6fe;
+  cursor:pointer;
 }
 
 /** New Styles since 3.0.0 Alpha */
@@ -259,66 +259,82 @@ label#rules-lbl {
 
 /* -- TAB STYLES ----------------------------- */
 dl.tabs {
-	float: left;
-	margin: 10px 0 -1px 0;
-	z-index: 50;
+  float: left;
+  margin: 10px 0 -1px 0;
+  z-index: 50;
 }
 
 dl.tabs dt {
-	float: left;
-	padding: 4px 10px;
-	border: 1px solid #ccc;
-	margin-left: 3px;
-	background: #e9e9e9;
-	color: #666;
+  float: left;
+  padding: 4px 10px;
+  border: 1px solid #ccc;
+  margin-left: 3px;
+  background: #e9e9e9;
+  color: #666;
 }
 
 dl.tabs dt.open {
-	background: #F9F9F9;
-	border-bottom: 1px solid #f9f9f9;
-	z-index: 100;
-	color: #000;
+  background: #F9F9F9;
+  border-bottom: 1px solid #f9f9f9;
+  z-index: 100;
+  color: #000;
 }
 
 div.current {
-	clear: both;
-	border: 1px solid #ccc;
-	padding: 10px 10px;
+  clear: both;
+  border: 1px solid #ccc;
+  padding: 10px 10px;
 }
 
 div.current dd {
-	padding: 0;
-	margin: 0;
+  padding: 0;
+  margin: 0;
 }
 
 dl#content-pane.tabs {
-	margin: 1px 0 0 0;
+  margin: 1px 0 0 0;
 }
 
 div.current fieldset {
-	border: none 0;
+  border: none 0;
 }
 
 div.current fieldset.adminform {
-	border: 1px #ccc solid;
+  border: 1px #ccc solid;
 }
 
 p.tab-description {
-	font-size: 1.091em;
-	margin-left: 0;
-	margin-top: 5px;
+  font-size: 1.091em;
+  margin-left: 0;
+  margin-top: 5px;
 }
 
 /* Tab changes for accessibility */
 dl.tabs dt h3 {
-	margin: 0;
-	padding: 0;
-	font-size: 1em;
-	font-weight: normal;
+  margin: 0;
+  padding: 0;
+  font-size: 1em;
+  font-weight: normal;
 }
 
 dl.tabs dt h3 a:link {
-	color:#333333;
-	outline:medium none;
-	text-decoration:none;
+  color:#333333;
+  outline:medium none;
+  text-decoration:none;
+}
+
+/* Modal reject popup */
+#jg-reject-popup .modal-body {
+  max-height: 250px;
+  overflow-y: auto;
+}
+
+#jg-reject-popup #jg-reject-image{
+  max-height: 200px;
+  width: auto;
+}
+
+#jg-reject-owner p, #jg-reject-no-owner p {
+  margin-top: 5px;
+  margin-bottom: 20px;
 }


### PR DESCRIPTION
In some cases resp for some screen resolutions the command buttons of the Reject popup are not visible resp concealed. This pull request fixes that.
Additionally the tabs were replaced by spaces in the file admin.joomgallery.css.
