### PR TITLE
Fix pagination glitches in back end images view

### DIFF
--- a/administrator/components/com_joomgallery/models/images.php
+++ b/administrator/components/com_joomgallery/models/images.php
@@ -78,7 +78,7 @@ class JoomGalleryModelImages extends JoomGalleryModel
     if(empty($this->_images))
     {
       $query = $this->_buildQuery();
-      $this->_images = $this->_getList($query, $this->getState('list.start'), $this->getState('list.limit'));
+      $this->_images = $this->_getList($query, $this->getStart(), $this->getState('list.limit'));
     }
 
     return $this->_images;
@@ -942,10 +942,11 @@ class JoomGalleryModelImages extends JoomGalleryModel
   {
     $app = JFactory::getApplication();
 
-    $cur_state  = $app->getUserState($key, $default);
-    $new_state  = JRequest::getVar($request, null, 'default', $type);
+    $old_state = $app->getUserState($key);
+    $cur_state = (!is_null($old_state)) ? $old_state : $default;
+    $new_state = JRequest::getVar($request, null, 'default', $type);
 
-    if($cur_state != $new_state && $resetPage)
+    if($cur_state != $new_state && !is_null($new_state) && !is_null($old_state) && $resetPage)
     {
       JRequest::setVar('limitstart', 0);
     }


### PR DESCRIPTION
This pull request fixes some pagination glitches in the back end images view.

After applying the patch the image manager should display the correct page (the one which was last visited before) after for instance deleting an item (redirect) or when coming back from another view. 

The patch also prevents displaying an empty list after deleting the last single item of the last page of a list with multiple pages.
