### PR TITLE
Fix links to managers (approval) in JoomGallery control panel

### DIFF
--- a/administrator/components/com_joomgallery/models/categories.php
+++ b/administrator/components/com_joomgallery/models/categories.php
@@ -453,8 +453,7 @@ class JoomGalleryModelCategories extends JoomGalleryModel
     }
 
     // Filter by owner
-    $owner = $this->getState('filter.owner');
-    if($owner !== '')
+    if($owner = $this->getState('filter.owner'))
     {
       $query->where('c.owner = '.(int) $owner);
     }

--- a/administrator/components/com_joomgallery/models/images.php
+++ b/administrator/components/com_joomgallery/models/images.php
@@ -832,8 +832,7 @@ class JoomGalleryModelImages extends JoomGalleryModel
     }
 
     // Filter by owner
-    $owner = $this->getState('filter.owner');
-    if($owner !== '')
+    if($owner = $this->getState('filter.owner'))
     {
       $query->where('a.owner = '.(int) $owner);
     }

--- a/administrator/components/com_joomgallery/views/control/tmpl/default_notapprovedcomments.php
+++ b/administrator/components/com_joomgallery/views/control/tmpl/default_notapprovedcomments.php
@@ -15,10 +15,10 @@ $approved_states  = array(1 => array('reject', 'COM_JOOMGALLERY_COMMON_APPROVED'
                       <?php echo JHTML::_('jgrid.state', $approved_states, $item->approved, $i, '', false); ?>
                     </td>
                     <td class="center" width="25">
-                      <?php echo JHTML::_('joomgallery.minithumbimg', $item, 'jg_minithumb', 'href="'.JRoute::_('index.php?option='._JOOM_OPTION.'&controller=comments&filter_state=4&filter_order=c.cmtdate&filter_order_Dir=desc'), true); ?>
+                      <?php echo JHTML::_('joomgallery.minithumbimg', $item, 'jg_minithumb', 'href="'.JRoute::_('index.php?option='._JOOM_OPTION.'&controller=comments&filter[state]=4&list[fullordering]=c.cmtdate DESC'), true); ?>
                     </td>
                     <td>
-                      <a href="<?php echo JRoute::_('index.php?option='._JOOM_OPTION.'&controller=comments&filter_state=4&filter_order=c.cmtdate&filter_order_Dir=desc');?>">
+                      <a href="<?php echo JRoute::_('index.php?option='._JOOM_OPTION.'&controller=comments&filter[state]=4&list[fullordering]=c.cmtdate DESC');?>">
                         <?php echo $item->cmttext; ?></a>
                     </td>
                     <td class="small nowrap">

--- a/administrator/components/com_joomgallery/views/control/tmpl/default_notapprovedimages.php
+++ b/administrator/components/com_joomgallery/views/control/tmpl/default_notapprovedimages.php
@@ -15,10 +15,10 @@ $approved_states = array( 1 => array('reject', 'COM_JOOMGALLERY_COMMON_APPROVED'
                       <?php echo JHTML::_('jgrid.state', $approved_states, $item->approved, $i, '', false); ?>
                     </td>
                     <td class="center" width="25">
-                      <?php echo JHTML::_('joomgallery.minithumbimg', $item, 'jg_minithumb', 'href="'.JRoute::_('index.php?option='._JOOM_OPTION.'&controller=images&filter_state=4&filter_order=a.imgdate&filter_order_Dir=desc'), true); ?>
+                      <?php echo JHTML::_('joomgallery.minithumbimg', $item, 'jg_minithumb', 'href="'.JRoute::_('index.php?option='._JOOM_OPTION.'&controller=images&filter[state]=4&list[fullordering]=a.imgdate DESC'), true); ?>
                     </td>
                     <td>
-                      <a href="<?php echo JRoute::_('index.php?option='._JOOM_OPTION.'&controller=images&filter_state=4&filter_order=a.imgdate&filter_order_Dir=desc');?>">
+                      <a href="<?php echo JRoute::_('index.php?option='._JOOM_OPTION.'&controller=images&filter[state]=4&list[fullordering]=a.imgdate DESC');?>">
                         <?php echo $this->escape($item->imgtitle); ?></a>
                       <span class="small">
                         <?php echo JText::sprintf('COM_JOOMGALLERY_COMMON_CATEGORY_VAR', $this->escape($item->category_name)); ?>


### PR DESCRIPTION
After implementing #55 and #58 the links in the back end control panel to the respective managers in order to approve images or comments were not working correctly (filters and ordering were not applied correctly).  
