### PR TITLE
Fix form field joomuser popup

### DIFF
--- a/administrator/components/com_joomgallery/models/fields/joomuser.php
+++ b/administrator/components/com_joomgallery/models/fields/joomuser.php
@@ -156,7 +156,12 @@ class JFormFieldJoomUser extends JFormFieldUser
       }
     }
 
-    return $this->getPopupInput();
+    if(version_compare(JVERSION, '3.5', 'lt'))
+    {
+      return $this->getPopupInput();
+    }
+
+    return parent::getInput();
   }
 
   /**
@@ -289,24 +294,9 @@ class JFormFieldJoomUser extends JFormFieldUser
     // Add the script to the document head.
     JFactory::getDocument()->addScriptDeclaration(implode("\n", $script));
 
-    // Load the current user name if available.
-    $config = JoomConfig::getInstance();
-    $type   = $config->get('jg_realname') ? 'name' : 'username';
-    $table  = JTable::getInstance('user');
-
-    if($this->value)
-    {
-      $table->load($this->value);
-    }
-    else
-    {
-      $table->$type = JText::_($hint);
-      $this->value = '';
-    }
-
     // Create a dummy text field with the user name.
     $html[] = '<div class="input-append">';
-    $html[] = '  <input type="text" id="' . $this->id . '_name"' . ' value="' . htmlspecialchars($table->$type, ENT_COMPAT, 'UTF-8')
+    $html[] = '  <input type="text" id="' . $this->id . '_name"' . ' value="' . htmlspecialchars($this->loadUser(), ENT_COMPAT, 'UTF-8')
                 . '"' . ' readonly' . $attr . ' />';
 
     // Create the user select button.
@@ -334,5 +324,59 @@ class JFormFieldJoomUser extends JFormFieldUser
     $html[] = '<input type="hidden" id="' . $this->id . '" name="' . $this->name . '" value="' . $this->value . '"' . $required . ' />';
 
     return implode("\n", $html);
+  }
+
+  /**
+   * Get the data that is going to be passed to the layout
+   *
+   * @return  array
+   * @since 3.2
+   */
+  public function getLayoutData()
+  {
+    // Get the basic field data
+    $data = JFormField::getLayoutData();
+
+    $extraData = array(
+        'userName'  => $this->loadUser(),
+        'groups'    => $this->getGroups(),
+        'excluded'  => $this->getExcluded()
+    );
+
+    if(empty($this->onchange))
+    {
+      $extraData['onchnage'] = 'if (this.val() == 0) {'
+                                 . 'setTimeout(function(){ jQuery("#' . $this->id. '").val("'
+                                 . JText::_((!empty($this->hint) ? $this->hint : 'COM_JOOMGALLERY_COMMON_NO_USER'))
+                                 . '"); }, 200);}';
+    }
+
+    return array_merge($data, $extraData);
+  }
+
+  /**
+   * Load the user if available.
+   *
+   * @return  string  User's name resp. user's username.
+   * @since 3.2
+   */
+  protected function loadUser()
+  {
+    // Load the current user name if available.
+    $config = JoomConfig::getInstance();
+    $type   = $config->get('jg_realname') ? 'name' : 'username';
+    $table  = JTable::getInstance('user');
+
+    if($this->value)
+    {
+      $table->load($this->value);
+    }
+    else
+    {
+      $table->$type = JText::_((!empty($this->hint) ? $this->hint : 'COM_JOOMGALLERY_COMMON_NO_USER'));
+      $this->value = '';
+    }
+
+    return $table->$type;
   }
 }

--- a/administrator/components/com_joomgallery/models/fields/joomuser.php
+++ b/administrator/components/com_joomgallery/models/fields/joomuser.php
@@ -345,7 +345,7 @@ class JFormFieldJoomUser extends JFormFieldUser
 
     if(empty($this->onchange))
     {
-      $extraData['onchnage'] = 'if (this.val() == 0) {'
+      $extraData['onchange'] = 'if (this.val() == 0) {'
                                  . 'setTimeout(function(){ jQuery("#' . $this->id. '").val("'
                                  . JText::_((!empty($this->hint) ? $this->hint : 'COM_JOOMGALLERY_COMMON_NO_USER'))
                                  . '"); }, 200);}';

--- a/administrator/components/com_joomgallery/models/images.php
+++ b/administrator/components/com_joomgallery/models/images.php
@@ -282,6 +282,13 @@ class JoomGalleryModelImages extends JoomGalleryModel
           JFactory::getApplication()->setUserState('joom.images.filter.' . $name, $value);
         }
 
+        // Special case for owner filter since Joomla! 3.5 when using modal user selection
+        if($name == 'owner' && $value == 0)
+        {
+          $value = '';
+          JFactory::getApplication()->setUserState('joom.images.filter.' . $name, $value);
+        }
+
         $this->setState('filter.' . $name, $value);
 
         if($value)


### PR DESCRIPTION
Due to recent changes of the user form field in Joomla 3.5 the user resp owner selection via popup with the joomuser form field is not working any more. You can check this by trying to assign an owner to a category in the backend category view.

This pull request fixes that.
