### PR TITLE
Fix setting of permissions in the backend category and image view

### DIFF
--- a/administrator/components/com_joomgallery/views/category/tmpl/form.php
+++ b/administrator/components/com_joomgallery/views/category/tmpl/form.php
@@ -207,6 +207,7 @@
       <?php if($this->_user->authorise('core.admin', _JOOM_OPTION.'.category.'.$this->item->cid)): ?>
         <div class="tab-pane" id="permissions">
           <?php echo $this->form->getInput('rules'); ?>
+          <?php $this->_doc->addScript($this->_ambit->getScript('permissions.js')); ?>
         </div>
       <?php endif; ?>
     </div>

--- a/administrator/components/com_joomgallery/views/category/view.html.php
+++ b/administrator/components/com_joomgallery/views/category/view.html.php
@@ -101,6 +101,9 @@ class JoomGalleryViewCategory extends JoomGalleryView
       $form->setValue('notice', null, JText::sprintf('COM_JOOMGALLERY_CATMAN_THUMBNAIL_NOT_AVAILABLE', $item->thumbnail));
     }
 
+    JText::script('JLIB_RULES_NOT_ALLOWED');
+    JText::script('JLIB_RULES_ALLOWED');
+
     $this->assignRef('item', $item);
     $this->assignRef('isNew', $isNew);
     $this->assignRef('form', $form);

--- a/administrator/components/com_joomgallery/views/image/tmpl/form.php
+++ b/administrator/components/com_joomgallery/views/image/tmpl/form.php
@@ -328,6 +328,7 @@ Joomla.submitbutton = function(task)
 <?php if($this->_user->authorise('core.admin', _JOOM_OPTION.'.image.'.$this->item->id)): ?>
         <div class="tab-pane" id="permissions">
           <?php echo $this->form->getInput('rules'); ?>
+          <?php $this->_doc->addScript($this->_ambit->getScript('permissions.js')); ?>
         </div>
 <?php endif; ?>
         <!-- End Tab Permissions -->

--- a/administrator/components/com_joomgallery/views/image/view.html.php
+++ b/administrator/components/com_joomgallery/views/image/view.html.php
@@ -158,6 +158,9 @@ class JoomGalleryViewImage extends JoomGalleryView
     }
     $form->setValue('imagelib', null, $thumbsource);
 
+    JText::script('JLIB_RULES_NOT_ALLOWED');
+    JText::script('JLIB_RULES_ALLOWED');
+
     $this->assignRef('item',              $item);
     $this->assignRef('isNew',             $isNew);
     $this->assignRef('form',              $form);

--- a/media/joomgallery/js/permissions.js
+++ b/media/joomgallery/js/permissions.js
@@ -63,13 +63,13 @@ var sendPermissions = function(event)
         {
           jQuery(element).parents().next('td').find('span')
             .removeClass('label label-important').addClass('label label-success')
-            .html('Allowed');
+            .html(Joomla.JText._('JLIB_RULES_ALLOWED'));
         }
         else
         {
           jQuery(element).parents().next('td').find('span')
             .removeClass('label label-success').addClass('label label-important')
-            .html('Not Allowed.');
+            .html(Joomla.JText._('JLIB_RULES_NOT_ALLOWED'));
         }
       }
       else

--- a/media/joomgallery/js/permissions.js
+++ b/media/joomgallery/js/permissions.js
@@ -1,0 +1,97 @@
+// $HeadURL: https://joomgallery.org/svn/joomgallery/JG-3/JG/trunk/media/joomgallery/js/permissions.js $
+// $Id: permissions.js 4078 2016-04-05 10:56:43Z erftralle $
+/******************************************************************************\
+**   JoomGallery 3                                                            **
+**   By: JoomGallery::ProjectTeam                                             **
+**   Copyright (C) 2008 - 2016  JoomGallery::ProjectTeam                      **
+**   Based on: JoomGallery 1.0.0 by JoomGallery::ProjectTeam                  **
+**   Released under GNU GPL Public License                                    **
+**   License: http://www.gnu.org/copyleft/gpl.html or have a look             **
+**   at administrator/components/com_joomgallery/LICENSE.TXT                  **
+\******************************************************************************/
+
+/**
+ * Override for Joomla!'s function to send permissions via AJAX to com_config
+ * application controller.
+ * 
+ * @since   3.2
+ */
+var sendPermissions = function(event)
+{
+  // Set the icon while storing the values
+  var icon = document.getElementById('icon_' + this.id);
+  icon.removeAttribute('class');
+  icon.setAttribute('style', 'background: url(../media/system/images/modal/spinner.gif); display: inline-block; width: 16px; height: 16px');
+
+  // Get values and prepare GET-Parameter
+  var id = this.id.split('_');
+  var asset = null;
+  var option = getUrlParam('option');
+  var controller = getUrlParam('controller');  
+  var task = getUrlParam('task');
+  var value = this.value;
+  
+  if (controller == 'categories' && task == 'edit')
+  {
+    asset = option + '.category.' + getUrlParam('cid');
+  }
+  else if (controller == 'images' && task == 'edit' )
+  {
+    asset = option + '.image.' + getUrlParam('cid');
+  }
+  
+  var title = document.getElementById('title').value;
+  
+  var data = '&comp=' + asset + '&action=' + id[1] + '&rule=' + id[2] + '&value=' + value + '&title=' + title;
+  var url = 'index.php?option=com_config&task=config.store&format=raw' + data;
+
+  if(asset != null)
+  {
+    // Doing ajax request
+    jQuery.ajax({
+      type: 'GET',
+      url: url,
+      datatype: 'JSON'
+    }).success(function (response) {
+      var element = event.target;
+      var resp = JSON.parse(response);
+      if (resp.data == 'true')
+      {
+        icon.removeAttribute('style');
+        icon.setAttribute('class', 'icon-save');
+        if (value == '1')
+        {
+          jQuery(element).parents().next('td').find('span')
+            .removeClass('label label-important').addClass('label label-success')
+            .html('Allowed');
+        }
+        else
+        {
+          jQuery(element).parents().next('td').find('span')
+            .removeClass('label label-success').addClass('label label-important')
+            .html('Not Allowed.');
+        }
+      }
+      else
+      {
+        var msg = { error: [Joomla.JText._('JLIB_RULES_DATABASE_FAILURE ')] };
+        Joomla.renderMessages(msg);
+        icon.removeAttribute('style');
+        icon.setAttribute('class', 'icon-cancel');
+      }
+      if (resp.message == 0)
+      {
+        var msg = { error: [Joomla.JText._('JLIB_RULES_SAVE_BEFORE_CHANGE_PERMISSIONS')] };
+        Joomla.renderMessages(msg);
+        icon.removeAttribute('style');
+        icon.setAttribute('class', 'icon-cancel');
+      }
+    }).fail(function() {
+      // Set cancel icon on http failure
+      var msg = { error: [Joomla.JText._('JLIB_RULES_REQUEST_FAILURE')] };
+      Joomla.renderMessages(msg);
+      icon.removeAttribute('style');
+      icon.setAttribute('class', 'icon-cancel');
+    })
+  }
+}


### PR DESCRIPTION
The setting of permissions (Joomla! ACL) in the backend category and image view is not working correctly any more, most probably since setting of these access rights has been AJAXified.

Find additional information [here.](http://www.forum.joomgallery.net/index.php/topic,6376.msg30587.html#msg30587)

I fixed the problem by adding an override javascript function, which is adapted to the JoomGallery needs.
