### PR TITLE
Fix sending messages via phpmailer

### DIFF
--- a/components/com_joomgallery/helpers/messenger.php
+++ b/components/com_joomgallery/helpers/messenger.php
@@ -454,7 +454,25 @@ class JoomMessenger extends JObject
       return true;
     }
 
-    if(JFactory::getMailer()->sendMail($from, $fromname, null, $this->_subject,  $this->_text, false, null, $recipients) !== true)
+
+    try
+    {
+      $mailer = JFactory::getMailer();
+
+      $mailer->setSubject($this->_subject);
+      $mailer->setBody($this->_text);
+      $mailer->isHtml(false);
+      $mailer->addBcc($recipients);
+      $mailer->setSender(array($from, $fromname));
+
+      $result = $mailer->Send();
+    }
+    catch(phpmailerException $ex)
+    {
+      return false;
+    }
+
+    if($result !== true)
     {
       return false;
     }

--- a/components/com_joomgallery/helpers/messenger.php
+++ b/components/com_joomgallery/helpers/messenger.php
@@ -454,6 +454,7 @@ class JoomMessenger extends JObject
       return true;
     }
 
+    $result = false;
 
     try
     {


### PR DESCRIPTION
The sending of messages (in case of an image upload, image download, new comment ...) to the configured recipients via E-Mail is broken since Joomla! 3.5. 

The reason for that is the enabling of the exception handling of the PHPMailer by Joomla. When trying to add a address NULL to the recipients the exception is thrown and the further processing stops.

See also 
[JoomGallery forum](http://www.forum.joomgallery.net/index.php/topic,6382.msg30611.html#msg30611)
and
[JoomGallery forum](http://www.forum.joomgallery.net/index.php/topic,6383.msg30612.html#msg30612)

This pull request fixes that.  
