### PR TITLE
Fix broken thumbnail selection for categories with MiniJoom

### DIFF
--- a/administrator/components/com_joomgallery/views/mini/tmpl/default_minis.php
+++ b/administrator/components/com_joomgallery/views/mini/tmpl/default_minis.php
@@ -7,7 +7,7 @@
       foreach($this->images as $row): ?>
     <div class="jg_bu_mini">
 <?php if($row->thumb_src): ?>
-      <a href="javascript:if(typeof window.parent.<?php echo $this->prefix; ?>_selectimage == 'function'){window.parent.<?php echo $this->prefix; ?>_selectimage(<?php echo $row->id; ?>, '<?php echo str_replace("'", "\'", $this->escape(stripslashes($row->imgtitle))); ?>', '<?php echo $this->object; ?>', '<?php echo $row->imgthumbname; ?>', radioGetCheckedValue(document.id('imagesForm').type));}else{insertJoomPluWithId('<?php echo $row->id; ?>', '<?php echo $this->e_name; ?>');}" title="<?php echo $row->overlib; ?>" class="hasMiniTip">
+      <a href="javascript:if(typeof window.parent.<?php echo $this->prefix; ?>_selectimage == 'function'){window.parent.<?php echo $this->prefix; ?>_selectimage(<?php echo $row->id; ?>, '<?php echo str_replace("'", "\'", $this->escape(stripslashes($row->imgtitle))); ?>', '<?php echo $this->object; ?>', '<?php echo $row->imgthumbname; ?>', document.id('imagesForm') != null ? radioGetCheckedValue(document.id('imagesForm').type) : 'thumb');}else{insertJoomPluWithId('<?php echo $row->id; ?>', '<?php echo $this->e_name; ?>');}" title="<?php echo $row->overlib; ?>" class="hasMiniTip">
         <img src="<?php echo $row->thumb_src; ?>" border="0" height="40" width="40" alt="Thumbnail" /></a>
 <?php endif;
       if(!$row->thumb_src): ?>


### PR DESCRIPTION
The thumbnail selection for a category in the front and back end is not working any more since 2d4933158e28606954829970c468717d1ec0f8e3.
See also http://www.forum.joomgallery.net/index.php/topic,6394.0.html.

This pull request should fix that.
