### PR TITLE
Transliterate category alias

### DIFF
--- a/administrator/components/com_joomgallery/models/category.php
+++ b/administrator/components/com_joomgallery/models/category.php
@@ -248,7 +248,10 @@ class JoomGalleryModelCategory extends JoomGalleryModel
         $data['alias']  = $alias;
       //}
     }
-
+		if (empty(trim($data['alias']))) { // Transliterate category alias
+			$data['alias'] = JFilterOutput::stringURLSafe($data['name']);
+			$this->generateNewTitle($data['parent_id'], $data['alias'], $data['name']);
+		}
     if(isset($data['password']) && $data['password'])
     {
       $salt = JUserHelper::genRandomPassword(32);


### PR DESCRIPTION
When saving a category in non-latin a date-alias is created. 
This patch is to automatically transliterate the alias from title

Screenshots to illustrate the problem:
Now: <a href="http://view.xscreenshot.com/5de03d106328a60d26f76175a1c2d0fa" rel="group[xscreenshot]"  class="jcepopup"><img width="300" src="http://static.xscreenshot.com/2016/05/15/01/screen_5de03d106328a60d26f76175a1c2d0fa"></a>

After the patch applied:
<a href="http://view.xscreenshot.com/be335d70b52769582196afadc4266457" rel="group[xscreenshot]"  class="jcepopup"><img width="300" src="http://static.xscreenshot.com/2016/05/15/01/screen_be335d70b52769582196afadc4266457"></a>