### PR TITLE
Fix GitHub logo not showing and link targets

### DIFF
--- a/administrator/components/com_joomgallery/views/help/tmpl/default.php
+++ b/administrator/components/com_joomgallery/views/help/tmpl/default.php
@@ -65,10 +65,10 @@
       <div class="well well-small">
         <div class="module-title nav-header"><?php echo JText::_('COM_JOOMGALLERY_HLPIFO_TEAM'); ?></div>
         <div class="text-center">
-          <p><?php echo JText::sprintf('COM_JOOMGALLERY_HLPIFO_TEAM_TEXT', '<a href="http://en.joomgallery.net/">JoomGallery::ProjectTeam</a>', '<a href="https://github.com/JoomGallery">GitHub</a>'); ?></p>
+          <p><?php echo JText::sprintf('COM_JOOMGALLERY_HLPIFO_TEAM_TEXT', '<a href="http://en.joomgallery.net/team.html" target="_blank">JoomGallery::ProjectTeam</a>', '<a href="https://github.com/JoomGallery" target="_blank">GitHub</a>'); ?></p>
           <p><?php echo JText::_('COM_JOOMGALLERY_HLPIFO_TEAM_CONTRIBUTORS'); ?></p>
           <p><small class="muted"><?php echo JText::_('COM_JOOMGALLERY_HLPIFO_TEAM_CONTRIBUTORS_HINT'); ?></small></p>
-          <a href="https://github.com/JoomGallery"><img width="300" src="http://localhost/3.5.1/media/joomgallery/images/others/GitHub_logo.png" alt="GitHub Logo"></a></div>
+          <a href="https://github.com/JoomGallery" target="_blank"><img width="300" src="<?php echo $this->_ambit->getIcon('others/GitHub_logo.png'); ?>" alt="GitHub Logo"></a></div>
       </div>
     </div>
   </div>

--- a/administrator/language/en-GB/en-GB.com_joomgallery.ini
+++ b/administrator/language/en-GB/en-GB.com_joomgallery.ini
@@ -1080,7 +1080,6 @@ COM_JOOMGALLERY_HLPIFO_PROJECT_WEBSITE="Project website (Documentation, FAQ, Dow
 COM_JOOMGALLERY_HLPIFO_SPONSORS="If you want to support our project in any other way - be it by participation or as sponsor - just write an email to:<br />"
 COM_JOOMGALLERY_HLPIFO_SUPPORT_FORUM="Support Forum"
 COM_JOOMGALLERY_HLPIFO_TEAM="The Team"
-COM_JOOMGALLERY_HLPIFO_TEAM_CONTRIBUTORS="The most active contributors to the main JoomGallery repository are listed <a href="_QQ_"https://github.com/JoomGallery/JoomGallery/graphs/contributors"_QQ_">here</a>."
 COM_JOOMGALLERY_HLPIFO_TEAM_CONTRIBUTORS_HINT="If you're missing your user name there please make sure that you have added your local Git commit email address to your profile on GitHub."
 COM_JOOMGALLERY_HLPIFO_TEAM_TEXT="JoomGallery is maintained by the %1$s and developed by the community on %2$s."
 COM_JOOMGALLERY_HLPIFO_THANKS="Thanks / Credits"
@@ -1554,3 +1553,9 @@ COM_JOOMGALLERY_UPLOAD_UNSUPPORTED_RESIZING_METHOD="Unsupported resizing method"
 COM_JOOMGALLERY_UPLOAD_UPLOAD="Upload"
 JNO="No"
 JYES="Yes"
+;------------------------------------------------------------------------------------
+; Deleted, new or changed language constants after the release of JoomGallery 3.3.1
+;------------------------------------------------------------------------------------
+;Changed
+;-------
+COM_JOOMGALLERY_HLPIFO_TEAM_CONTRIBUTORS="The most active contributors to the main JoomGallery repository are listed <a href="_QQ_"https://github.com/JoomGallery/JoomGallery/graphs/contributors"_QQ_" target="_QQ_"_blank"_QQ_">here</a>."


### PR DESCRIPTION
The GitHub logo in the 'The Team' section of the 'Help and Information' screen is not displayed.
In my opinion the links there should also open in new window, like all the others on this page already do. 
The 'JoomGallery::ProjectTeam' link should lead to the 'team' page, in my opinion. 
