### PR TITLE
Fix double translations

### DIFF
--- a/administrator/components/com_joomgallery/views/categories/view.html.php
+++ b/administrator/components/com_joomgallery/views/categories/view.html.php
@@ -79,8 +79,8 @@ class JoomGalleryViewCategories extends JoomGalleryView
 
     if(($this->_config->get('jg_disableunrequiredchecks') || count(JoomHelper::getAuthorisedCategories('core.edit.state'))) && $this->pagination->total)
     {
-      JToolbarHelper::publishList('publish', JText::_('COM_JOOMGALLERY_COMMON_PUBLISH'));
-      JToolbarHelper::unpublishList('unpublish', JText::_('COM_JOOMGALLERY_COMMON_UNPUBLISH'));
+      JToolbarHelper::publishList('publish', 'COM_JOOMGALLERY_COMMON_PUBLISH');
+      JToolbarHelper::unpublishList('unpublish', 'COM_JOOMGALLERY_COMMON_UNPUBLISH');
       JToolbarHelper::divider();
     }
 

--- a/administrator/components/com_joomgallery/views/images/view.html.php
+++ b/administrator/components/com_joomgallery/views/images/view.html.php
@@ -76,8 +76,8 @@ class JoomGalleryViewImages extends JoomGalleryView
 
     if($canDo->get('core.edit.state') && $this->pagination->total)
     {
-      JToolbarHelper::publishList('publish', JText::_('COM_JOOMGALLERY_COMMON_PUBLISH'));
-      JToolbarHelper::unpublishList('unpublish', JText::_('COM_JOOMGALLERY_COMMON_UNPUBLISH'));
+      JToolbarHelper::publishList('publish', 'COM_JOOMGALLERY_COMMON_PUBLISH');
+      JToolbarHelper::unpublishList('unpublish', 'COM_JOOMGALLERY_COMMON_UNPUBLISH');
       JToolbarHelper::custom('approve', 'upload.png', 'upload_f2.png', 'COM_JOOMGALLERY_IMGMAN_TOOLBAR_APPROVE');
       JToolbarHelper::divider();
     }


### PR DESCRIPTION
The second parameter of the function `JToolbarHelper::publishList()` may not be an already translated text.
