### PR TITLE
Fix: Allow spaces in image file names

### DIFF
--- a/administrator/components/com_joomgallery/models/fields/fineuploader.php
+++ b/administrator/components/com_joomgallery/models/fields/fineuploader.php
@@ -176,7 +176,7 @@ class JFormFieldFineuploader extends JFormField
         },
         onValidate: function(fileData) {
           if(!jg_filenamewithjs) {
-            var searchwrongchars = /[^a-zA-Z0-9_-]/;
+            var searchwrongchars = /[^a-zA-Z0-9 _-]/;
             if(searchwrongchars.test(fileData.name.substr(0, fileData.name.lastIndexOf('.')))) {
               this._itemError('fileNameError', fileData.name);
               return false;

--- a/media/joomgallery/js/upload.js
+++ b/media/joomgallery/js/upload.js
@@ -102,7 +102,7 @@ function joomOnSubmit()
   if(!jg_filenamewithjs)
   {
     var filenames_not_ok = false;
-    var searchwrongchars = /[^a-zA-Z0-9_-]/;
+    var searchwrongchars = /[^a-zA-Z0-9 _-]/;
     var lastbackslash = new Array();
     var endoffilename = new Array();
     var filename = new Array();


### PR DESCRIPTION
As described in the tab General 'Settings - Replacements' of the configuration manager spaces should be allowed in file names even if 'Allow special characters in filenames for uploads' ist set to 'No'.

See also http://www.forum.en.joomgallery.net/index.php?topic=7441.msg23265#msg23265.
