### PR TITLE
Fix removing an image from the favourites

### DIFF
--- a/components/com_joomgallery/models/favourites.php
+++ b/components/com_joomgallery/models/favourites.php
@@ -93,7 +93,7 @@ class JoomGalleryModelFavourites extends JoomGalleryModel
     // Set the image id
     $view = JRequest::getCmd('view');
     $task = JRequest::getCmd('task');
-    if(   $view != 'favourites'
+    if(  ($view != 'favourites' || $task == 'removeimage')
       &&  $view != 'downloadzip'
       &&  $task != 'removeall'
       &&  $task != 'switchlayout'


### PR DESCRIPTION
Removing an image from the favourites list is not possible when using a menu item link _**JoomGallery » Favourites: Default Layout**_. 

This PR should fix that.

See also http://www.forum.en.joomgallery.net/index.php?topic=7428.0 .