### PR TITLE
Use of 'read more' in description

### DIFF
--- a/administrator/components/com_joomgallery/models/forms/category.xml
+++ b/administrator/components/com_joomgallery/models/forms/category.xml
@@ -95,7 +95,7 @@
       class="inputbox"
       filter="JComponentHelper::filterText"
       buttons="true"
-      hide="readmore,pagebreak"
+      hide="pagebreak"
     />
     <field
       name="publishhiddenstate"

--- a/administrator/components/com_joomgallery/models/forms/editimages.xml
+++ b/administrator/components/com_joomgallery/models/forms/editimages.xml
@@ -58,7 +58,7 @@
       label="COM_JOOMGALLERY_COMMON_DESCRIPTION"
       filter="JComponentHelper::filterText"
       buttons="true"
-      hide="readmore,pagebreak"
+      hide="pagebreak"
       cols="50"
     />
     <field

--- a/administrator/components/com_joomgallery/models/forms/image.xml
+++ b/administrator/components/com_joomgallery/models/forms/image.xml
@@ -81,7 +81,7 @@
       label="COM_JOOMGALLERY_COMMON_DESCRIPTION"
       filter="JComponentHelper::filterText"
       buttons="true"
-      hide="readmore,pagebreak"
+      hide="pagebreak"
     />
     <field 
       id="detail_catid"

--- a/components/com_joomgallery/helpers/helper.php
+++ b/components/com_joomgallery/helpers/helper.php
@@ -970,28 +970,28 @@ class JoomHelper
   }
 
   /**
-   * Returns the introtext of a description
+   * Returns the introtext of a category or image description
    *
-   * @return  object  
+   * @param   string  $description  The description where only the introtext should be returned
+   * @return  string  The introtext of the description
    * @since   3.4
    */
-  public static function getintrotext($description)
+  public static function getIntrotext($description)
   {
     $introtext = null;
 
-    if (isset($description))
+    if(isset($description))
     {
       $pattern = '#<hr\s+id=("|\')system-readmore("|\')\s*\/*>#i';
       $tagPos = preg_match($pattern, $description);
 
-      if ($tagPos == 0)
+      if($tagPos == 0)
       {
         $introtext = $description;
       }
       else
       {
-        $ergebnis = preg_split($pattern, $description, 0);
-        $introtext = $ergebnis[0];
+        $introtext = preg_split($pattern, $description, 0)[0];
       }
     }
 
@@ -999,21 +999,22 @@ class JoomHelper
   }
 
   /**
-   * Returns the fulltext of a description
+   * Returns the fulltext of a category or image description
    *
-   * @return  object  
+   * @param   string  $description  The description where the fulltext should be returned
+   * @return  string  The fulltext of the description
    * @since   3.4
    */
-  public static function getfulltext($description)
+  public static function getFulltext($description)
   {
     $fulltext = null;
 
-    if (isset($description))
+    if(isset($description))
     {
       $pattern = '#<hr\s+id=("|\')system-readmore("|\')\s*\/*>#i';
       $tagPos = preg_match($pattern, $description);
 
-      if ($tagPos == 0)
+      if($tagPos == 0)
       {
         $fulltext = $description;
       }

--- a/components/com_joomgallery/helpers/helper.php
+++ b/components/com_joomgallery/helpers/helper.php
@@ -968,4 +968,61 @@ class JoomHelper
 
     return $val;
   }
+
+  /**
+   * Returns the introtext of a description
+   *
+   * @return  object  
+   * @since   3.4
+   */
+  public static function getintrotext($description)
+  {
+    $introtext = null;
+
+    if (isset($description))
+    {
+      $pattern = '#<hr\s+id=("|\')system-readmore("|\')\s*\/*>#i';
+      $tagPos = preg_match($pattern, $description);
+
+      if ($tagPos == 0)
+      {
+        $introtext = $description;
+      }
+      else
+      {
+        $ergebnis = preg_split($pattern, $description, 0);
+        $introtext = $ergebnis[0];
+      }
+    }
+
+    return $introtext;
+  }
+
+  /**
+   * Returns the fulltext of a description
+   *
+   * @return  object  
+   * @since   3.4
+   */
+  public static function getfulltext($description)
+  {
+    $fulltext = null;
+
+    if (isset($description))
+    {
+      $pattern = '#<hr\s+id=("|\')system-readmore("|\')\s*\/*>#i';
+      $tagPos = preg_match($pattern, $description);
+
+      if ($tagPos == 0)
+      {
+        $fulltext = $description;
+      }
+      else
+      {
+        $fulltext = preg_replace($pattern, '', $description);
+      }
+    }
+
+    return $fulltext;
+  }
 }

--- a/components/com_joomgallery/interface.php
+++ b/components/com_joomgallery/interface.php
@@ -131,6 +131,8 @@ class JoomInterface
     $this->_config['showlastcomment'] = 0;
     // - Make use of hidden images and images in hidden categories
     $this->_config['showhidden']      = 0;
+    // - Show only introtext of description
+    $this->_config['showdescriptionintrotext'] = 1;
 
     // Store the config for being able to reset it later on (if useful)
     $this->storeConfig();
@@ -718,7 +720,14 @@ class JoomInterface
     }
     if($this->getConfig('showdescription')  && $obj->imgtext)
     {
-      $output .= '  <li>'. JText::sprintf('COM_JOOMGALLERY_COMMON_DESCRIPTION_VAR', $obj->imgtext).'</li>';
+      if($this->getConfig('showdescriptionintrotext') == 1)
+      {
+        $output .= '  <li>'.JText::sprintf('COM_JOOMGALLERY_COMMON_DESCRIPTION_VAR', JoomHelper::getintrotext($obj->imgtext)).'</li>';
+      }
+      else
+      {
+        $output .= '  <li>'.JText::sprintf('COM_JOOMGALLERY_COMMON_DESCRIPTION_VAR', JoomHelper::getfulltext($obj->imgtext)).'</li>';
+      }
     }
     if($this->getConfig('showcmtdate') == 1 && !is_null($obj->cmtdate))
     {

--- a/components/com_joomgallery/interface.php
+++ b/components/com_joomgallery/interface.php
@@ -722,11 +722,11 @@ class JoomInterface
     {
       if($this->getConfig('showdescriptionintrotext') == 1)
       {
-        $output .= '  <li>'.JText::sprintf('COM_JOOMGALLERY_COMMON_DESCRIPTION_VAR', JoomHelper::getintrotext($obj->imgtext)).'</li>';
+        $output .= '  <li>'.JText::sprintf('COM_JOOMGALLERY_COMMON_DESCRIPTION_VAR', JoomHelper::getIntrotext($obj->imgtext)).'</li>';
       }
       else
       {
-        $output .= '  <li>'.JText::sprintf('COM_JOOMGALLERY_COMMON_DESCRIPTION_VAR', JoomHelper::getfulltext($obj->imgtext)).'</li>';
+        $output .= '  <li>'.JText::sprintf('COM_JOOMGALLERY_COMMON_DESCRIPTION_VAR', JoomHelper::getFulltext($obj->imgtext)).'</li>';
       }
     }
     if($this->getConfig('showcmtdate') == 1 && !is_null($obj->cmtdate))

--- a/components/com_joomgallery/models/forms/edit.xml
+++ b/components/com_joomgallery/models/forms/edit.xml
@@ -57,7 +57,7 @@
       description="COM_JOOMGALLERY_EDIT_DESCRIPTION_TIP"
       filter="JComponentHelper::filterText"
       buttons="true"
-      hide="pagebreak,readmore"
+      hide="pagebreak"
     />
     <field
       id="published"

--- a/components/com_joomgallery/models/forms/editcategory.xml
+++ b/components/com_joomgallery/models/forms/editcategory.xml
@@ -55,7 +55,7 @@
       description="COM_JOOMGALLERY_EDITCATEGORY_DESCRIPTION_TIP"
       filter="JComponentHelper::filterText"
       buttons="true"
-      hide="readmore,pagebreak"
+      hide="pagebreak"
     />
     <field
       name="access"

--- a/components/com_joomgallery/models/forms/quickedit.xml
+++ b/components/com_joomgallery/models/forms/quickedit.xml
@@ -35,7 +35,7 @@
       description="COM_JOOMGALLERY_EDIT_DESCRIPTION_TIP"
       filter="JComponentHelper::filterText"
       buttons="true"
-      hide="pagebreak,readmore"
+      hide="pagebreak"
     />
     <field
       name="imgauthor"

--- a/components/com_joomgallery/views/category/view.html.php
+++ b/components/com_joomgallery/views/category/view.html.php
@@ -656,7 +656,7 @@ class JoomGalleryViewCategory extends JoomGalleryView
       }
 
       // show only intro-text in subcategories
-      $categories[$key]->description = JoomHelper::getintrotext($categories[$key]->description);
+      $categories[$key]->description = JoomHelper::getIntrotext($categories[$key]->description);
 
       // Icon for quick upload at sub-category thumbnail
       if(     $this->_config->get('jg_uploadiconsubcat')
@@ -749,7 +749,7 @@ class JoomGalleryViewCategory extends JoomGalleryView
     }
 
     // Display Full text of category
-    $cat->description = JoomHelper::getfulltext($cat->description);
+    $cat->description = JoomHelper::getFulltext($cat->description);
 
     foreach($images as $key => $image)
     {
@@ -834,7 +834,7 @@ class JoomGalleryViewCategory extends JoomGalleryView
       }
 
       // show only intro-text of images
-      $images[$key]->imgtext = JoomHelper::getintrotext($images[$key]->imgtext);
+      $images[$key]->imgtext = JoomHelper::getIntrotext($images[$key]->imgtext);
 
       $images[$key]->event  = new stdClass();
 

--- a/components/com_joomgallery/views/category/view.html.php
+++ b/components/com_joomgallery/views/category/view.html.php
@@ -655,6 +655,9 @@ class JoomGalleryViewCategory extends JoomGalleryView
         $categories[$key]->link = JRoute::_('index.php?view=category&catid='.$category->cid);
       }
 
+      // show only intro-text in subcategories
+      $categories[$key]->description = JoomHelper::getintrotext($categories[$key]->description);
+
       // Icon for quick upload at sub-category thumbnail
       if(     $this->_config->get('jg_uploadiconsubcat')
           &&  (   $this->_user->authorise('joom.upload', _JOOM_OPTION.'.category.'.$category->cid)
@@ -745,6 +748,9 @@ class JoomGalleryViewCategory extends JoomGalleryView
       }
     }
 
+    // Display Full text of category
+    $cat->description = JoomHelper::getfulltext($cat->description);
+
     foreach($images as $key => $image)
     {
       $cropx    = null;
@@ -826,6 +832,9 @@ class JoomGalleryViewCategory extends JoomGalleryView
         // Set the imgtitle by default
         $images[$key]->atagtitle = 'title="'.$images[$key]->imgtitle.'"';
       }
+
+      // show only intro-text of images
+      $images[$key]->imgtext = JoomHelper::getintrotext($images[$key]->imgtext);
 
       $images[$key]->event  = new stdClass();
 

--- a/components/com_joomgallery/views/detail/view.html.php
+++ b/components/com_joomgallery/views/detail/view.html.php
@@ -221,6 +221,9 @@ class JoomGalleryViewDetail extends JoomGalleryView
       $this->_doc->setMetaData('author', $image->author);
     }
 
+    // Show fulltext of description
+    $image->imgtext = JoomHelper::getfulltext($image->imgtext);
+
     // Set the title attribute in a tag with title and/or description of image
     // if a box is activated
     if(    (!is_numeric($this->_config->get('jg_bigpic_open')) || $this->_config->get('jg_bigpic_open') > 1)
@@ -438,7 +441,7 @@ class JoomGalleryViewDetail extends JoomGalleryView
           // Description
           if($row->imgtext != '')
           {
-            $description =JoomHelper::fixForJS($row->imgtext);
+            $description = JoomHelper::fixForJS(JoomHelper::getintrotext($row->imgtext));
           }
           else
           {

--- a/components/com_joomgallery/views/detail/view.html.php
+++ b/components/com_joomgallery/views/detail/view.html.php
@@ -222,7 +222,7 @@ class JoomGalleryViewDetail extends JoomGalleryView
     }
 
     // Show fulltext of description
-    $image->imgtext = JoomHelper::getfulltext($image->imgtext);
+    $image->imgtext = JoomHelper::getFulltext($image->imgtext);
 
     // Set the title attribute in a tag with title and/or description of image
     // if a box is activated
@@ -441,7 +441,7 @@ class JoomGalleryViewDetail extends JoomGalleryView
           // Description
           if($row->imgtext != '')
           {
-            $description = JoomHelper::fixForJS(JoomHelper::getintrotext($row->imgtext));
+            $description = JoomHelper::fixForJS(JoomHelper::getFulltext($row->imgtext));
           }
           else
           {

--- a/components/com_joomgallery/views/gallery/view.html.php
+++ b/components/com_joomgallery/views/gallery/view.html.php
@@ -184,7 +184,7 @@ class JoomGalleryViewGallery extends JoomGalleryView
       }
 
       // show only intro-text of category description
-      $categories[$key]->description = JoomHelper::getintrotext($categories[$key]->description);
+      $categories[$key]->description = JoomHelper::getIntrotext($categories[$key]->description);
 
       // Get number of images in category and sub-categories
       $imgshits = JoomHelper::getNumberOfImgHits($categories[$key]->cid);

--- a/components/com_joomgallery/views/gallery/view.html.php
+++ b/components/com_joomgallery/views/gallery/view.html.php
@@ -183,6 +183,9 @@ class JoomGalleryViewGallery extends JoomGalleryView
         $categories[$key]->isnew = JoomHelper::checkNewCatg($categories[$key]->cid);
       }
 
+      // show only intro-text of category description
+      $categories[$key]->description = JoomHelper::getintrotext($categories[$key]->description);
+
       // Get number of images in category and sub-categories
       $imgshits = JoomHelper::getNumberOfImgHits($categories[$key]->cid);
       $categories[$key]->pictures = $imgshits[0];


### PR DESCRIPTION
It is almost an adaptation of the functionality from the Joomla! articles.
This will only display the introduction text of the description in the following places:
-In the category view the image description
-When viewing subcategories the category description
Via a new parameter in the interface.php the output can also be adjusted in modules and plugins.
Improvement suggestions are welcome.