### PR TITLE
Adding a modal header and footer to thumbnail selection field popup

### DIFF
--- a/administrator/components/com_joomgallery/models/fields/thumbnail.php
+++ b/administrator/components/com_joomgallery/models/fields/thumbnail.php
@@ -91,11 +91,6 @@ class JFormFieldThumbnail extends JFormField
 
     $doc->addScriptDeclaration(implode("\n", $script));
 
-    // Remove bottom border from modal header as we will not have a title
-    $css[] = '  #modalSelectThumbnail .modal-header {';
-    $css[] = '    border-bottom: none;';
-    $css[] = '  }';
-
     $doc->addStyleDeclaration(implode("\n", $css));
 
     // Get the image title
@@ -128,8 +123,10 @@ class JFormFieldThumbnail extends JFormField
     $html[] = JHtmlBootstrap::renderModal(
                 'modalSelectThumbnail', array(
                   'url'     => $link . '&amp;' . JSession::getFormToken() . '=1"',
+                  'title'   => ($app->isAdmin() ? JText::_('COM_JOOMGALLERY_CATMAN_SELECT_THUMBNAIL_TIP') : JText::_('COM_JOOMGALLERY_COMMON_SELECT_THUMBNAIL_TIP')),
                   'width'   => '620px',
-                  'height'  => '390px'
+                  'height'  => '390px',
+                  'footer'  => '<a role="button" class="btn" data-dismiss="modal" aria-hidden="true">' . JText::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</a>'
                  )
               );
 

--- a/administrator/components/com_joomgallery/models/fields/thumbnail.php
+++ b/administrator/components/com_joomgallery/models/fields/thumbnail.php
@@ -120,6 +120,13 @@ class JFormFieldThumbnail extends JFormField
                 . ($app->isAdmin() ? JText::_('COM_JOOMGALLERY_CATMAN_SELECT_THUMBNAIL') : JText::_('COM_JOOMGALLERY_COMMON_SELECT'))
                 . '</a>';
 
+    $html[] = '<button id="' . $this->id . '_clear" class="btn' . ($this->value ? '' : ' hidden') . ' hasTooltip" title="'
+                . ($app->isAdmin() ? JHtml::tooltipText('COM_JOOMGALLERY_CATMAN_REMOVE_CATTHUMB_TIP') : JHtml::tooltipText('COM_JOOMGALLERY_COMMON_REMOVE_CATTHUMB_TIP'))
+                . '" onclick="return joom_clearthumb()"><span class="icon-remove"></span></button>';
+
+    $html[] = '</span>';
+    $html[] = '<input type="hidden" id="' . $this->id . '_id" name="' . $this->name . '" value="' . $this->value . '"/>';
+
     $html[] = JHtmlBootstrap::renderModal(
                 'modalSelectThumbnail', array(
                   'url'     => $link . '&amp;' . JSession::getFormToken() . '=1"',
@@ -127,15 +134,8 @@ class JFormFieldThumbnail extends JFormField
                   'width'   => '620px',
                   'height'  => '390px',
                   'footer'  => '<a role="button" class="btn" data-dismiss="modal" aria-hidden="true">' . JText::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</a>'
-                 )
+                )
               );
-
-    $html[] = '<button id="' . $this->id . '_clear" class="btn' . ($this->value ? '' : ' hidden') . ' hasTooltip" title="'
-                . ($app->isAdmin() ? JHtml::tooltipText('COM_JOOMGALLERY_CATMAN_REMOVE_CATTHUMB_TIP') : JHtml::tooltipText('COM_JOOMGALLERY_COMMON_REMOVE_CATTHUMB_TIP'))
-                . '" onclick="return joom_clearthumb()"><span class="icon-remove"></span></button>';
-
-    $html[] = '</span>';
-    $html[] = '<input type="hidden" id="' . $this->id . '_id" name="' . $this->name . '" value="' . $this->value . '"/>';
 
     return implode("\n", $html);
   }


### PR DESCRIPTION
When opening the thumbnail selection popup in for instance the backend category edit view the modal has no header and footer so that there is no other chance to close it, without selecting a thumbnail by clicking on the backdrop. This is not a good user experience.

This pull request adds a modal header and footer to the thumbnail selection popup.