### PR TITLE
Adding a modal header and footer to image selection field popup

### DIFF
--- a/administrator/components/com_joomgallery/models/fields/image.php
+++ b/administrator/components/com_joomgallery/models/fields/image.php
@@ -101,16 +101,6 @@ class JFormFieldImage extends JFormField
                 . '<i class="icon-image"></i> ' . JText::_('JSELECT')
                 . '</a>';
 
-    $html[] = JHtmlBootstrap::renderModal(
-                'modalSelectImage', array(
-                  'url'     => $link . '&amp;' . JSession::getFormToken() . '=1"',
-                  'title'   => JText::_('COM_JOOMGALLERY_LAYOUT_COMMON_CHOOSE_IMAGE'),
-                  'width'   => '620px',
-                  'height'  => '390px',
-                  'footer'  => '<a role="button" class="btn" data-dismiss="modal" aria-hidden="true">' . JText::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</a>'
-                 )
-              );
-
     $html[] = '</span>';
 
     if($this->required)
@@ -123,6 +113,16 @@ class JFormFieldImage extends JFormField
     }
 
     $html[] = '<input class="' . $class . '" type="hidden" id="' . $this->id . '" name="' . $this->name . '" value="' . (int) $this->value . '"/>';
+
+    $html[] = JHtmlBootstrap::renderModal(
+                'modalSelectImage', array(
+                  'url'     => $link . '&amp;' . JSession::getFormToken() . '=1"',
+                  'title'   => JText::_('COM_JOOMGALLERY_LAYOUT_COMMON_CHOOSE_IMAGE'),
+                  'width'   => '620px',
+                  'height'  => '390px',
+                  'footer'  => '<a role="button" class="btn" data-dismiss="modal" aria-hidden="true">' . JText::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</a>'
+                )
+              );
 
     return implode("\n", $html);
   }

--- a/administrator/components/com_joomgallery/models/fields/image.php
+++ b/administrator/components/com_joomgallery/models/fields/image.php
@@ -77,11 +77,6 @@ class JFormFieldImage extends JFormField
 
     $doc->addScriptDeclaration(implode("\n", $script));
 
-    // Remove bottom border from modal header as we will not have a title
-    $css[] = '  #modalSelectImage .modal-header {';
-    $css[] = '    border-bottom: none;';
-    $css[] = '  }';
-
     $doc->addStyleDeclaration(implode("\n", $css));
 
     JTable::addIncludePath(JPATH_ADMINISTRATOR . '/components/com_joomgallery/tables');
@@ -109,8 +104,10 @@ class JFormFieldImage extends JFormField
     $html[] = JHtmlBootstrap::renderModal(
                 'modalSelectImage', array(
                   'url'     => $link . '&amp;' . JSession::getFormToken() . '=1"',
+                  'title'   => JText::_('COM_JOOMGALLERY_LAYOUT_COMMON_CHOOSE_IMAGE'),
                   'width'   => '620px',
-                  'height'  => '390px'
+                  'height'  => '390px',
+                  'footer'  => '<a role="button" class="btn" data-dismiss="modal" aria-hidden="true">' . JText::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</a>'
                  )
               );
 


### PR DESCRIPTION
When opening the image selection popup while for instance creating a new menu entry for a JoomGallery detail view the modal has no header and footer so that there is no other chance to close it, without selecting an image, by clicking on the backdrop. This is not a good user experience.

This pull request adds a modal header and footer to the image selection popup.