### PR TITLE
Fix misaligned toolbar buttons in the backend views

### DIFF
--- a/media/joomgallery/css/admin.joomgallery.css
+++ b/media/joomgallery/css/admin.joomgallery.css
@@ -246,12 +246,6 @@ label#rules-lbl {
   margin-left:100px;
 }
 
-/* Workaround for the bootstrap accordion to work in IE9 */
-/* should be removed with bootstrap 2.1.1 */ 
-.collapse {
-  overflow: hidden !important;
-}
-
 /* Edit images view: Space between boxes */
 #jg_movecopy{
   padding:0px 10px;


### PR DESCRIPTION
When opening a backend view (e.g. image manager) and changing the browsers window size to 720x1280px the toolbar buttons are not correctly aligned on the left side of the screen.

That's because of the CSS rule
```
/* Workaround for the bootstrap accordion to work in IE9 */
/* should be removed with bootstrap 2.1.1 */ 
.collapse {
  overflow: hidden !important;
}
```
in the **admin.joomgallery.css** file. 

The Bootstrap version is 2.3.2 now, the workaround can be removed now.