### PR TITLE
fix problems in backend views

### DIFF
--- a/administrator/components/com_joomgallery/views/category/tmpl/form.php
+++ b/administrator/components/com_joomgallery/views/category/tmpl/form.php
@@ -82,11 +82,11 @@
             </div>
           </div>
         </div>
-
         <div class="row-fluid">
           <h4><?php echo JText::_('JDETAILS');?></h4>
           <hr />
-
+        </div>
+        <div class="row-fluid">
           <div class="span6">
             <div class="control-group">
               <div class="control-label">

--- a/administrator/components/com_joomgallery/views/image/tmpl/form.php
+++ b/administrator/components/com_joomgallery/views/image/tmpl/form.php
@@ -304,7 +304,7 @@ jQuery(document).ready(function() {
 <?php if(!$this->isNew): ?>
         <div class="tab-pane" id="replace_files">
           <div class="control-group">
-            <div class="control-label alert alert-info">
+            <div class="alert alert-info">
               <?php echo $this->form->getLabel('spacer', 'files'); ?>
             </div>
             <div class="controls">


### PR DESCRIPTION
DE: 
Behebt Probleme mit der mehrspaltigen Darstellung im Backend bei Kategorien und Bilder
1. Kategorien: Anzeige der 2. Spalte nach der Kategorie-id.
2. Bilder: Breite des Hinweistextes im Tab "Bild ersetzen"
EN: 
Fixes issues with multi-column design in the backend for categories and images
1. Categories: Display of the 2nd column after the category id.
2. Images: Width of the text in the "Replace image files" tab