### PR TITLE
Fix FTP upload option 'Delete from FTP' not checked by default

### DIFF
--- a/administrator/components/com_joomgallery/models/forms/ftpupload.xml
+++ b/administrator/components/com_joomgallery/models/forms/ftpupload.xml
@@ -110,6 +110,7 @@
         description="COM_JOOMGALLERY_UPLOAD_DELETE_AFTER_UPLOAD_DESC"
         value="1"
         default="1"
+        checked="true"
       />
       <field
         name="original_delete"


### PR DESCRIPTION
According to the description of the option 'Delete from FTP' in the back end FTP Upload this option should be checked by default. It has been this way until recent changes of the form field 'Checkbox' (by Joomla!) do prevent this behaviour.

This pull request restores this default behaviour. 