### PR TITLE
Fix creating a new configuration in extented configuration manager

### DIFF
--- a/administrator/components/com_joomgallery/includes/popup.php
+++ b/administrator/components/com_joomgallery/includes/popup.php
@@ -18,14 +18,14 @@ defined('JPATH_PLATFORM') or die;
  * @subpackage  Toolbar
  * @since       3.0
  */
-class JToolbarButtonPopup extends JToolbarButton
+class JToolbarButtonJoomPopup extends JToolbarButton
 {
 	/**
 	 * Button type
 	 *
 	 * @var    string
 	 */
-	protected $_name = 'Popup';
+	protected $_name = 'JoomPopup';
 
 	/**
 	 * Fetch the HTML for the button

--- a/administrator/components/com_joomgallery/views/configs/view.html.php
+++ b/administrator/components/com_joomgallery/views/configs/view.html.php
@@ -57,7 +57,7 @@ class JoomGalleryViewConfigs extends JoomGalleryView
     JToolBarHelper::title(JText::_('COM_JOOMGALLERY_CONFIGS_CONFIGURATION_MANAGER'), 'equalizer');
 
     $toolbar = JToolbar::getInstance('toolbar');
-    $toolbar->appendButton('Popup', 'new', 'JTOOLBAR_NEW', 'index.php?option='._JOOM_OPTION.'&amp;controller=config&amp;layout=new&amp;tmpl=component', 400, 350, 0, 0, '', 'COM_JOOMGALLERY_CONFIGS_NEW_HEADING', 'jg-new-popup', 'new');
+    $toolbar->appendButton('JoomPopup', 'new', 'JTOOLBAR_NEW', 'index.php?option='._JOOM_OPTION.'&amp;controller=config&amp;layout=new&amp;tmpl=component', 400, 350, 0, 0, '', 'COM_JOOMGALLERY_CONFIGS_NEW_HEADING', 'jg-new-popup', 'new');
 
     JToolbarHelper::editList('edit');
 

--- a/media/joomgallery/css/admin.joomgallery.css
+++ b/media/joomgallery/css/admin.joomgallery.css
@@ -245,6 +245,9 @@ label#rules-lbl {
 #jg-new-popup .chzn-container{
   margin-left:100px;
 }
+#jg-new-popup #formNew{
+  margin: 0px;
+}
 
 /* Edit images view: Space between boxes */
 #jg_movecopy{


### PR DESCRIPTION
This is a proposal to fix issue #137. It should be backward compatible, the small CSS addition removes the margin at the bottom of the footer.