### PR TITLE
Display the title and upload button for empty category

### DIFF
--- a/components/com_joomgallery/views/category/tmpl/default.php
+++ b/components/com_joomgallery/views/category/tmpl/default.php
@@ -6,8 +6,9 @@ if(count($this->categories)):
   echo $this->loadTemplate('subcategories');
 endif;
 
+echo $this->loadTemplate('head');
+
 if(count($this->images)):
-  echo $this->loadTemplate('head');
   echo $this->loadTemplate('images');
 endif;
 


### PR DESCRIPTION
It's much better to have a title and the upload button "+" on the right, when the category is empty.