### PR TITLE
Fix deleting of categories containing images in maintenance manager

### DIFF
--- a/administrator/components/com_joomgallery/models/maintenance.php
+++ b/administrator/components/com_joomgallery/models/maintenance.php
@@ -469,11 +469,12 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
 
     JArrayHelper::toInteger($cids);
 
+    $query = $this->_db->getQuery(true);
+
     if($refids)
     {
       // Get selected image IDs
-      $query = $this->_db->getQuery(true)
-            ->select('refid')
+      $query->select('refid')
             ->from($this->_db->qn(_JOOM_TABLE_MAINTENANCE))
             ->where('id IN ('.implode(',', $cids).')')
             ->where('type = 0');
@@ -791,7 +792,6 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
       {
         // Category deleted
         $count++;
-        $row->reorder('parent_id = '.$row->parent_id);
 
         // Delete the category in the maintenance table
         $query = $this->_db->getQuery(true)


### PR DESCRIPTION
This is a fix for issue #143 .