### PR TITLE
Remove deprecated functions (for Joomla! 4)

### DIFF
--- a/administrator/components/com_joomgallery/controller.php
+++ b/administrator/components/com_joomgallery/controller.php
@@ -13,8 +13,6 @@
 
 defined('_JEXEC') or die('Direct Access to this location is not allowed.');
 
-jimport('joomla.application.component.controller');
-
 /**
  * JoomGallery Component Controller
  *
@@ -24,20 +22,12 @@ jimport('joomla.application.component.controller');
 class JoomGalleryController extends JControllerLegacy
 {
   /**
-   * JApplication object
-   *
-   * @access  protected
-   * @var     object
-   */
-  #var $_mainframe;
-
-  /**
    * JoomConfig object
    *
    * @access  protected
    * @var     object
    */
-  var $_config;
+  protected $_config;
 
   /**
    * JoomAmbit object
@@ -45,15 +35,7 @@ class JoomGalleryController extends JControllerLegacy
    * @access  protected
    * @var     object
    */
-  var $_ambit;
-
-  /**
-   * JUser object, holds the current user data
-   *
-   * @access  protected
-   * @var     object
-   */
-  #var $_user;
+  protected $_ambit;
 
   /**
    * JDatabase object
@@ -61,7 +43,7 @@ class JoomGalleryController extends JControllerLegacy
    * @access  protected
    * @var     object
    */
-  var $_db;
+  protected $_db;
 
   /**
    * Constructor
@@ -76,9 +58,6 @@ class JoomGalleryController extends JControllerLegacy
 
     $this->_ambit     = JoomAmbit::getInstance();
     $this->_config    = JoomConfig::getInstance();
-
-    /*$this->_mainframe = JFactory::getApplication('site');
-    $this->_user      = JFactory::getUser();*/
     $this->_db        = JFactory::getDBO();
 
     // Uncomment following line to disable update check

--- a/administrator/components/com_joomgallery/controllers/ajaxupload.php
+++ b/administrator/components/com_joomgallery/controllers/ajaxupload.php
@@ -32,7 +32,7 @@ class JoomGalleryControllerAjaxupload extends JoomGalleryController
     parent::__construct();
 
     // Set view
-    JRequest::setVar('view', 'ajaxupload');
+    $this->input->set('view', 'ajaxupload');
   }
 
   /**

--- a/administrator/components/com_joomgallery/controllers/ajaxupload.raw.php
+++ b/administrator/components/com_joomgallery/controllers/ajaxupload.raw.php
@@ -35,7 +35,7 @@ class JoomGalleryControllerAjaxupload extends JoomGalleryController
 
     $uploader = new JoomUpload();
 
-    if($image = $uploader->upload(JRequest::getCmd('type', 'ajax')))
+    if($image = $uploader->upload($this->input->getCmd('type', 'ajax')))
     {
       $result['success'] = true;
       if(is_object($image))

--- a/administrator/components/com_joomgallery/controllers/batchupload.php
+++ b/administrator/components/com_joomgallery/controllers/batchupload.php
@@ -32,7 +32,7 @@ class JoomGalleryControllerBatchupload extends JoomGalleryController
     parent::__construct();
 
     // Set view
-    JRequest::setVar('view', 'batchupload');
+    $this->input->set('view', 'batchupload');
   }
 
   /**
@@ -66,13 +66,13 @@ class JoomGalleryControllerBatchupload extends JoomGalleryController
   {
     require_once JPATH_COMPONENT.'/helpers/upload.php';
     $uploader = new JoomUpload();
-    if($uploader->upload(JRequest::getCmd('type', 'batch')))
+    if($uploader->upload($this->input->getCmd('type', 'batch')))
     {
       $msg  = JText::_('COM_JOOMGALLERY_UPLOAD_MSG_SUCCESSFULL');
       $url  = $this->_ambit->getRedirectUrl();
 
       // Set custom redirect if we are asked for that
-      if($redirect = JRequest::getVar('redirect', '', '', 'base64'))
+      if($redirect = $this->input->getBase64('redirect', ''))
       {
         $url_decoded  = base64_decode($redirect);
         if(JURI::isInternal($url))

--- a/administrator/components/com_joomgallery/controllers/categories.json.php
+++ b/administrator/components/com_joomgallery/controllers/categories.json.php
@@ -33,11 +33,11 @@ class JoomGalleryControllerCategories extends JoomGalleryController
 
     $model = $this->getModel('categories');
 
-    $action     = JRequest::getCmd('action');
-    $filter     = JRequest::getInt('filter');
-    $search     = JRequest::getString('searchstring');
-    $limitstart = JRequest::getInt('more');
-    $current    = JRequest::getInt('current');
+    $action     = $this->input->getCmd('action');
+    $filter     = $this->input->getInt('filter');
+    $search     = $this->input->getString('searchstring');
+    $limitstart = $this->input->getInt('more');
+    $current    = $this->input->getInt('current');
 
     echo new JJsonResponse($model->getAllowedCategories($action, $filter, $search, $limitstart, $current));
   }
@@ -55,9 +55,9 @@ class JoomGalleryControllerCategories extends JoomGalleryController
     JSession::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
 
 		// Get the arrays from the request
-		$pks	          = JRequest::getVar('cid',	null,	'post',	'array');
-		$order          = JRequest::getVar('order',	null, 'post', 'array');
-		$originalOrder  = explode(',', JRequest::getString('original_order_values'));
+    $pks	          = $this->input->post->get('cid',	null,	'array');
+    $order          = $this->input->post->get('order',	null, 'array');
+    $originalOrder  = explode(',', $this->input->getString('original_order_values'));
 
 		// Make sure something has changed
 		if($order !== $originalOrder)

--- a/administrator/components/com_joomgallery/controllers/categories.php
+++ b/administrator/components/com_joomgallery/controllers/categories.php
@@ -33,7 +33,7 @@ class JoomGalleryControllerCategories extends JoomGalleryController
     parent::__construct();
 
     // Set view
-    JRequest::setVar('view', 'categories');
+    $this->input->set('view', 'categories');
 
     // Register tasks
     $this->registerTask('new',              'edit');
@@ -41,7 +41,6 @@ class JoomGalleryControllerCategories extends JoomGalleryController
     $this->registerTask('save2new',         'save');
     $this->registerTask('save2copy',        'save');
     $this->registerTask('unpublish',        'publish');
-    #$this->registerTask('reject',          'approve');
     $this->registerTask('accesspublic',     'access');
     $this->registerTask('accessregistered', 'access');
     $this->registerTask('accessspecial',    'access');
@@ -59,8 +58,8 @@ class JoomGalleryControllerCategories extends JoomGalleryController
   function publish()
   {
     // Initialize variables
-    $cid      = JRequest::getVar('cid', array(), 'post', 'array');
-    $task     = JRequest::getCmd('task');
+    $cid      = $this->input->post->get('cid', array(), 'array');
+    $task     = $this->input->getCmd('task');
     $publish  = (int)($task == 'publish');
 
     if(empty($cid))
@@ -82,7 +81,7 @@ class JoomGalleryControllerCategories extends JoomGalleryController
 
     if($unchanged_categories)
     {
-      JError::raiseNotice(403, JText::plural('COM_JOOMGALLERY_CATMAN_ERROR_EDITSTATE_NOT_PERMITTED', $unchanged_categories));
+      JFactory::getApplication()->enqueueMessage(JText::plural('COM_JOOMGALLERY_CATMAN_ERROR_EDITSTATE_NOT_PERMITTED', $unchanged_categories), 'notice');
     }
 
     $model = $this->getModel('categories');
@@ -115,8 +114,8 @@ class JoomGalleryControllerCategories extends JoomGalleryController
   function approve()
   {
     // Initialize variables
-    $cid      = JRequest::getVar('cid', array(), 'post', 'array');
-    $task     = JRequest::getCmd('task');
+    $cid      = $this->input->post->get('cid', array(), 'array');
+    $task     = $this->input->getCmd('task');
     $publish  = ($task == 'approve');
 
     if(empty($cid))
@@ -138,7 +137,7 @@ class JoomGalleryControllerCategories extends JoomGalleryController
 
     if($unchanged_categories)
     {
-      JError::raiseNotice(403, JText::plural('COM_JOOMGALLERY_CATMAN_ERROR_EDITSTATE_NOT_PERMITTED', $unchanged_categories));
+      JFactory::getApplication()->enqueueMessage(JText::plural('COM_JOOMGALLERY_CATMAN_ERROR_EDITSTATE_NOT_PERMITTED', $unchanged_categories), 'notice');
     }
 
     $model = $this->getModel('categories');
@@ -170,7 +169,7 @@ class JoomGalleryControllerCategories extends JoomGalleryController
    */
   function remove()
   {
-    $ids = JRequest::getVar('cid', array(), '', 'array');
+    $ids = $this->input->get('cid', array(), 'array');
 
     $model = $this->getModel('categories');
     try
@@ -205,7 +204,7 @@ class JoomGalleryControllerCategories extends JoomGalleryController
    */
   function deletecompletely()
   {
-    $mainframe  = JFactory::getApplication('administrator');
+    $mainframe  = JFactory::getApplication();
     $categories = $mainframe->getUserState('joom.categories.delete.categories');
     $images     = $mainframe->getUserState('joom.categories.delete.images');
 
@@ -346,9 +345,9 @@ class JoomGalleryControllerCategories extends JoomGalleryController
    */
   function edit()
   {
-    JRequest::setVar('view',    'category');
-    JRequest::setVar('layout',  'form');
-    JRequest::setVar('hidemainmenu', 1);
+    $this->input->set('view', 'category');
+    $this->input->set('layout', 'form');
+    $this->input->set('hidemainmenu', 1);
 
     parent::display();
   }
@@ -366,7 +365,7 @@ class JoomGalleryControllerCategories extends JoomGalleryController
 
     // Check whether a redirect is requested
     $redirect = false;
-    if($url = JRequest::getVar('redirect', '', '', 'base64'));
+    if($url = $this->input->getBase64('redirect', ''))
     {
       $url = base64_decode($url);
       if(JURI::isInternal($url))
@@ -375,25 +374,27 @@ class JoomGalleryControllerCategories extends JoomGalleryController
       }
     }
 
-    if(JRequest::getCmd('task') == 'save2copy')
+    if($this->input->getCmd('task') == 'save2copy')
     {
       // Reset the ID and then treat the request as for apply.
       // This way a new category will be created and after that
       // it will be displayed right away
-      JRequest::setVar('cid', 0);
-      JRequest::setVar('task', 'apply');
+      $data = $this->input->post->get('jform', array(), 'array');
+      $data['cid'] = 0;
+      $this->input->post->set('jform', $data);
+      $this->input->set('task', 'apply');
     }
 
     if($cid = $model->store())
     {
       if(!$redirect)
       {
-        if(JRequest::getCmd('task') == 'save2new')
+        if($this->input->getCmd('task') == 'save2new')
         {
           // Reset the ID after storing so that we
           // will be redirected to an empty form
           $cid = 0;
-          JRequest::setVar('task', 'apply');
+          $this->input->set('task', 'apply');
         }
         $redirect = $this->_ambit->getRedirectUrl(null, $cid);
       }
@@ -422,11 +423,11 @@ class JoomGalleryControllerCategories extends JoomGalleryController
    */
   function order()
   {
-    $cid = JRequest::getVar('cid', array(), 'post', 'array');
+    $cid = $this->input->post->get('cid', array(), 'array');
 
     // Direction
     $dir  = 1;
-    $task = JRequest::getCmd('task');
+    $task = $this->input->getCmd('task');
     if($task == 'orderup')
     {
       $dir = -1;
@@ -459,12 +460,12 @@ class JoomGalleryControllerCategories extends JoomGalleryController
    */
   function saveOrder()
   {
-    JRequest::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
+    JSession::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
 
     // Get the arrays from the request
-    $pks            = JRequest::getVar('cid',  null,  'post',  'array');
-    $order          = JRequest::getVar('order',  null, 'post', 'array');
-    $originalOrder  = explode(',', JRequest::getString('original_order_values'));
+    $pks            = $this->input->post->get('cid', null, 'array');
+    $order          = $this->input->post->get('order',  null, 'array');
+    $originalOrder  = explode(',', $this->input->getString('original_order_values'));
 
     // Make sure something has changed
     if($order !== $originalOrder)
@@ -498,7 +499,7 @@ class JoomGalleryControllerCategories extends JoomGalleryController
   public function batch()
   {
     JSession::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
-  
+
     $vars = $this->input->post->get('batch', array(), 'array');
     $cid  = $this->input->post->get('cid', array(), 'array');
 

--- a/administrator/components/com_joomgallery/controllers/changelog.php
+++ b/administrator/components/com_joomgallery/controllers/changelog.php
@@ -33,6 +33,6 @@ class JoomGalleryControllerChangelog extends JoomGalleryController
     parent::__construct();
 
     // Set view
-    JRequest::setVar('view', 'changelog');
+    $this->input->set('view', 'changelog');
   }
 }

--- a/administrator/components/com_joomgallery/controllers/comments.php
+++ b/administrator/components/com_joomgallery/controllers/comments.php
@@ -32,7 +32,7 @@ class JoomGalleryControllerComments extends JoomGalleryController
     parent::__construct();
 
     // Set view
-    JRequest::setVar('view', 'comments');
+    $this->input->set('view', 'comments');
 
     // Register tasks
     $this->registerTask('unpublish',  'publish');
@@ -48,8 +48,8 @@ class JoomGalleryControllerComments extends JoomGalleryController
   public function publish()
   {
     // Initialize variables
-    $cid      = JRequest::getVar('cid', array(), 'post', 'array');
-    $task     = JRequest::getCmd('task');
+    $cid      = $this->input->post->get('cid', array(), 'array');
+    $task     = $this->input->getCmd('task');
     $publish  = ($task == 'publish');
 
     if(empty($cid))
@@ -84,8 +84,8 @@ class JoomGalleryControllerComments extends JoomGalleryController
   public function approve()
   {
     // Initialize variables
-    $cid      = JRequest::getVar('cid', array(), 'post', 'array');
-    $task     = JRequest::getCmd('task');
+    $cid      = $this->input->post->get('cid', array(), 'array');
+    $task     = $this->input->getCmd('task');
     $publish  = ($task == 'approve');
 
     if(empty($cid))
@@ -97,9 +97,12 @@ class JoomGalleryControllerComments extends JoomGalleryController
     $model = $this->getModel('comments');
     if($count = $model->publish($cid, $publish, 'approve'))
     {
-      if($count != 1){
+      if($count != 1)
+      {
         $msg = JText::sprintf($publish ? 'COM_JOOMGALLERY_COMMAN_MSG_COMMENTS_APPROVED' : 'COM_JOOMGALLERY_COMMAN_MSG_COMMENTS_REJECTED', $count);
-      } else {
+      }
+      else
+      {
         $msg = JText::_($publish ? 'COM_JOOMGALLERY_COMMAN_MSG_COMMENT_APPROVED' : 'COM_JOOMGALLERY_COMMAN_MSG_COMMENT_REJECTED');
       }
       $this->setRedirect($this->_ambit->getRedirectUrl(), $msg);
@@ -121,12 +124,19 @@ class JoomGalleryControllerComments extends JoomGalleryController
   {
     $model = $this->getModel('comments');
     $count = $model->delete();
-    if($count === false){
+
+    if($count === false)
+    {
       $msg = JText::_('COM_JOOMGALLERY_COMMAN_MSG_ERROR_DELETING_COMMENT');
-    } else {
-      if($count == 1){
+    }
+    else
+    {
+      if($count == 1)
+      {
         $msg = JText::_('COM_JOOMGALLERY_COMMAN_MSG_COMMENT_DELETED');
-      } else {
+      }
+      else
+      {
         $msg = JText::sprintf('COM_JOOMGALLERY_COMMAN_MSG_COMMENTS_DELETED', $count);
       }
     }
@@ -148,7 +158,7 @@ class JoomGalleryControllerComments extends JoomGalleryController
           ->from(_JOOM_TABLE_COMMENTS);
     $this->_db->setQuery($query);
 
-    if(!$this->_db->query())
+    if(!$this->_db->execute())
     {
       // Redirect to maintenance manager because this task is usually launched there
       $this->setRedirect($this->_ambit->getRedirectUrl('maintenance&tab=comments'), $this->_db->getErrorMsg(), 'error');
@@ -176,7 +186,7 @@ class JoomGalleryControllerComments extends JoomGalleryController
           ->where('i.id IS NULL');
     $this->_db->setQuery($query);
 
-    if(!$this->_db->query())
+    if(!$this->_db->execute())
     {
       // Redirect to maintenance manager because this task is usually launched there
       $this->setRedirect($this->_ambit->getRedirectUrl('maintenance&tab=comments'), $this->_db->getErrorMsg(), 'error');
@@ -191,7 +201,7 @@ class JoomGalleryControllerComments extends JoomGalleryController
           ->where('u.id IS NULL');
     $this->_db->setQuery($query);
 
-    if(!$this->_db->query())
+    if(!$this->_db->execute())
     {
       // Redirect to maintenance manager because this task is usually launched there
       $this->setRedirect($this->_ambit->getRedirectUrl('maintenance&tab=comments'), $this->_db->getErrorMsg(), 'error');

--- a/administrator/components/com_joomgallery/controllers/config.php
+++ b/administrator/components/com_joomgallery/controllers/config.php
@@ -47,11 +47,11 @@ class JoomGalleryControllerConfig extends JoomGalleryController
     // Set view
     if($this->_config->isExtended())
     {
-      JRequest::setVar('view', 'configs');
+      $this->input->set('view', 'configs');
     }
     else
     {
-      JRequest::setVar('view', 'config');
+      $this->input->set('view', 'config');
     }
   }
 
@@ -63,16 +63,16 @@ class JoomGalleryControllerConfig extends JoomGalleryController
    */
   public function edit()
   {
-    $id  = JRequest::getInt('id');
-    $cid = JRequest::getVar('cid', array(), 'post', 'array');
+    $id  = $this->input->getInt('id');
+    $cid = $this->input->post->get('cid', array(), 'array');
 
     if(!$id && count($cid) && $cid[0])
     {
-      JRequest::setVar('id', (int) $cid[0]);
+      $this->input->set('id', (int) $cid[0]);
     }
 
-    JRequest::setVar('view', 'config');
-    JRequest::setVar('hidemainmenu', 1);
+    $this->input->set('view', 'config');
+    $this->input->set('hidemainmenu', 1);
 
     parent::display();
   }
@@ -92,12 +92,12 @@ class JoomGalleryControllerConfig extends JoomGalleryController
     $group_id = 0;
     if($config->isExtended())
     {
-      $id = JRequest::getInt('id');
-      $existing_row = JRequest::getInt('based_on');
+      $id = $this->input->getInt('id');
+      $existing_row = $this->input->getInt('based_on');
 
       if(!$id)
       {
-        $group_id = JRequest::getInt('group_id');
+        $group_id = $this->input->getInt('group_id');
       }
     }
     else
@@ -105,7 +105,7 @@ class JoomGalleryControllerConfig extends JoomGalleryController
       $id = 1;
     }
 
-    $post = JRequest::get('post');
+    $post = $this->input->post->getArray();
 
     if(!$id = $config->save($post, $id, $existing_row, $group_id))
     {
@@ -114,7 +114,7 @@ class JoomGalleryControllerConfig extends JoomGalleryController
       return;
     }
 
-    $propagate_changes = JRequest::getBool('propagate_changes');
+    $propagate_changes = $this->input->getBool('propagate_changes');
 
     // The changes have to be propagated to the other config rows
     // if the default row was changed or if propagation is requested
@@ -129,7 +129,7 @@ class JoomGalleryControllerConfig extends JoomGalleryController
       $controller = '';
       if(!$config->isExtended())
       {
-        if(JRequest::getCmd('task') == 'apply')
+        if($this->input->getCmd('task') == 'apply')
         {
           $controller = 'config';
         }
@@ -155,7 +155,7 @@ class JoomGalleryControllerConfig extends JoomGalleryController
   public function remove()
   {
     $config = JoomConfig::getInstance('admin');
-    $cid    = JRequest::getVar('cid', array(), 'post', 'array');
+    $cid    = $this->input->post->get('cid', array(), 'array');
 
     if(!count($cid))
     {
@@ -173,7 +173,7 @@ class JoomGalleryControllerConfig extends JoomGalleryController
       }
       else
       {
-        JError::raiseWarning(500, $config->getError());
+        JFactory::getApplication()->enqueueMessage($config->getError(), 'error');
       }
     }
 
@@ -199,11 +199,11 @@ class JoomGalleryControllerConfig extends JoomGalleryController
    */
   public function order()
   {
-    $cid = JRequest::getVar('cid', array(), 'post', 'array');
+    $cid = $this->input->post->get('cid', array(), 'array');
 
     // Direction
     $dir  = 1;
-    $task = JRequest::getCmd('task');
+    $task = $this->input->getCmd('task');
     if($task == 'orderup')
     {
       $dir = -1;
@@ -228,8 +228,8 @@ class JoomGalleryControllerConfig extends JoomGalleryController
    */
   public function saveOrder()
   {
-    $cid    = JRequest::getVar('cid', array(0), 'post', 'array');
-    $order  = JRequest::getVar('order', array(0), 'post', 'array');
+    $cid    = $this->input->post->get('cid', array(0), 'array');
+    $order  = $this->input->post->get('order', array(0), 'array');
 
     // Create and load the categories table object
     $row = JTable::getInstance('joomgalleryconfig', 'Table');
@@ -244,7 +244,7 @@ class JoomGalleryControllerConfig extends JoomGalleryController
         $row->check();
         if(!$row->store())
         {
-          JError::raiseError( 500, $this->_db->getErrorMsg());
+          throw new Exception($this->_db->getErrorMsg());
 
           return false;
         }

--- a/administrator/components/com_joomgallery/controllers/control.php
+++ b/administrator/components/com_joomgallery/controllers/control.php
@@ -33,9 +33,9 @@ class JoomGalleryControllerControl extends JoomGalleryController
     parent::__construct();
 
     // Set view
-    if(JRequest::getCmd('view') != 'mini')
+    if($this->input->getCmd('view') != 'mini')
     {
-      JRequest::setVar('view', 'control');
+      $this->input->set('view', 'control');
     }
   }
 
@@ -50,7 +50,7 @@ class JoomGalleryControllerControl extends JoomGalleryController
    */
   function update()
   {
-    $extension  = JRequest::getCmd('extension', 0, 'get');
+    $extension  = $this->input->get->getCmd('extension', 0);
     $extensions = JoomExtensions::checkUpdate();
 
     if(!isset($extensions[$extension]['updatelink']) || !extension_loaded('curl'))
@@ -78,7 +78,7 @@ class JoomGalleryControllerControl extends JoomGalleryController
    */
   function install()
   {
-    $extension  = JRequest::getCmd('extension', 0, 'get');
+    $extension  = $this->input->get->getCmd('extension', 0);
     $extensions = JoomExtensions::getAvailableExtensions();
 
     if(!isset($extensions[$extension]['updatelink']) || !extension_loaded('curl'))

--- a/administrator/components/com_joomgallery/controllers/cssedit.php
+++ b/administrator/components/com_joomgallery/controllers/cssedit.php
@@ -48,7 +48,7 @@ class JoomGalleryControllerCssedit extends JoomGalleryController
     }
 
     // Set view
-    JRequest::setVar('view', 'cssedit');
+    $this->input->set('view', 'cssedit');
 
     $this->file = JPATH_ROOT.'/media/joomgallery/css/joom_local.css';
 
@@ -67,18 +67,19 @@ class JoomGalleryControllerCssedit extends JoomGalleryController
   {
     jimport('joomla.filesystem.file');
 
-    $content  = stripcslashes(JRequest::getVar('csscontent'));
+    $content  = stripcslashes($this->input->getString('csscontent'));
 
     if(!$content)
     {
       $this->setRedirect($this->_ambit->getRedirectUrl(), JText::_('COM_JOOMGALLERY_CSSMAN_MSG_EMPTY'), 'notice');
+
       return;
     }
 
     if(JFile::write($this->file, $content))
     {
       $controller = '';
-      if(JRequest::getCmd('task') == 'apply')
+      if($this->input->getCmd('task') == 'apply')
       {
         $controller = 'cssedit';
       }

--- a/administrator/components/com_joomgallery/controllers/ftpupload.php
+++ b/administrator/components/com_joomgallery/controllers/ftpupload.php
@@ -32,7 +32,7 @@ class JoomGalleryControllerFtpupload extends JoomGalleryController
     parent::__construct();
 
     // Set view
-    JRequest::setVar('view', 'ftpupload');
+    $this->input->set('view', 'ftpupload');
   }
 
   /**
@@ -66,13 +66,13 @@ class JoomGalleryControllerFtpupload extends JoomGalleryController
   {
     require_once JPATH_COMPONENT.'/helpers/upload.php';
     $uploader = new JoomUpload();
-    if($uploader->upload(JRequest::getCmd('type', 'ftp')))
+    if($uploader->upload($this->input->getCmd('type', 'ftp')))
     {
       $msg  = JText::_('COM_JOOMGALLERY_UPLOAD_MSG_SUCCESSFULL');
       $url  = $this->_ambit->getRedirectUrl();
 
       // Set custom redirect if we are asked for that
-      if($redirect = JRequest::getVar('redirect', '', '', 'base64'))
+      if($redirect = $this->input->getBase64('redirect', ''))
       {
         $url_decoded  = base64_decode($redirect);
         if(JURI::isInternal($url))

--- a/administrator/components/com_joomgallery/controllers/help.php
+++ b/administrator/components/com_joomgallery/controllers/help.php
@@ -33,7 +33,7 @@ class JoomGalleryControllerHelp extends JoomGalleryController
     parent::__construct();
 
     // Set view
-    JRequest::setVar('view', 'help');
+    $this->input->set('view', 'help');
   }
 
   /**
@@ -47,11 +47,11 @@ class JoomGalleryControllerHelp extends JoomGalleryController
    */
   function install()
   {
-    $language = JRequest::getCmd('language', 0, 'get');
+    $language = $this->input->get->getCmd('language', 0);
 
     if(!$this->_config->get('jg_checkupdate') || !$language || !extension_loaded('curl'))
     {
-      $link = base64_decode(JRequest::getCmd('downloadlink'));
+      $link = base64_decode($this->input->getCmd('downloadlink'));
       $this->setRedirect($this->_ambit->getRedirectUrl(), JText::sprintf('COM_JOOMGALLERY_ADMENU_MSG_ERROR_FETCHING_LANGUAGE_ZIP', $link), 'error');
     }
     else

--- a/administrator/components/com_joomgallery/controllers/images.json.php
+++ b/administrator/components/com_joomgallery/controllers/images.json.php
@@ -35,8 +35,8 @@ class JoomGalleryControllerImages extends JoomGalleryController
 
     $conditions = array();
 
-    $cid   = JRequest::getVar('cid', array(), 'post', 'array');
-    $order = JRequest::getVar('order', array(), 'post', 'array');
+    $cid   = $this->input->post->get('cid', array(), 'array');
+    $order = $this->input->post->get('order', array(), 'array');
     $user  = JFactory::getUser();
 
     $row = JTable::getInstance('joomgalleryimages', 'Table');

--- a/administrator/components/com_joomgallery/controllers/images.php
+++ b/administrator/components/com_joomgallery/controllers/images.php
@@ -32,7 +32,7 @@ class JoomGalleryControllerImages extends JoomGalleryController
     parent::__construct();
 
     // Set view
-    JRequest::setVar('view', JRequest::getCmd('view', 'images'));
+    $this->input->set('view', $this->input->getCmd('view', 'images'));
 
     // Register tasks
     $this->registerTask('new',              'edit');
@@ -58,8 +58,8 @@ class JoomGalleryControllerImages extends JoomGalleryController
   public function publish()
   {
     // Initialize variables
-    $cid      = JRequest::getVar('cid', array(), 'post', 'array');
-    $task     = JRequest::getCmd('task');
+    $cid      = $this->input->post->get('cid', array(), 'array');
+    $task     = $this->input->getCmd('task');
     $publish  = (int)($task == 'publish');
 
     if(empty($cid))
@@ -81,7 +81,7 @@ class JoomGalleryControllerImages extends JoomGalleryController
 
     if($unchanged_images)
     {
-      JError::raiseNotice(403, JText::plural('COM_JOOMGALLERY_IMGMAN_ERROR_EDITSTATE_NOT_PERMITTED', $unchanged_images));
+      JFactory::getApplication()->enqueueMessage(JText::plural('COM_JOOMGALLERY_IMGMAN_ERROR_EDITSTATE_NOT_PERMITTED', $unchanged_images), 'notice');
     }
 
     $model = $this->getModel('images');
@@ -113,8 +113,8 @@ class JoomGalleryControllerImages extends JoomGalleryController
   public function feature()
   {
     // Initialize variables
-    $cid      = JRequest::getVar('cid', array(), 'post', 'array');
-    $task     = JRequest::getCmd('task');
+    $cid      = $this->input->post->get('cid', array(), 'array');
+    $task     = $this->input->getCmd('task');
     $feature  = (int)($task == 'feature');
 
     if(empty($cid))
@@ -136,7 +136,7 @@ class JoomGalleryControllerImages extends JoomGalleryController
 
     if($unchanged_images)
     {
-      JError::raiseNotice(403, JText::plural('COM_JOOMGALLERY_IMGMAN_ERROR_EDITSTATE_NOT_PERMITTED', $unchanged_images));
+      JFactory::getApplication()->enqueueMessage(JText::plural('COM_JOOMGALLERY_IMGMAN_ERROR_EDITSTATE_NOT_PERMITTED', $unchanged_images), 'notice');
     }
 
     $model = $this->getModel('images');
@@ -168,8 +168,8 @@ class JoomGalleryControllerImages extends JoomGalleryController
   public function approve()
   {
     // Initialize variables
-    $cid      = JRequest::getVar('cid', array(), 'post', 'array');
-    $task     = JRequest::getCmd('task');
+    $cid      = $this->input->post->get('cid', array(), 'array');
+    $task     = $this->input->getCmd('task');
     $publish  = -1;
     if($task == 'approve')
     {
@@ -195,7 +195,7 @@ class JoomGalleryControllerImages extends JoomGalleryController
 
     if($unchanged_images)
     {
-      $this->_mainframe->enqueueMessage(JText::plural('COM_JOOMGALLERY_IMGMAN_ERROR_EDITSTATE_NOT_PERMITTED', $unchanged_images), 'notice');
+      JFactory::getApplication()->enqueueMessage(JText::plural('COM_JOOMGALLERY_IMGMAN_ERROR_EDITSTATE_NOT_PERMITTED', $unchanged_images), 'notice');
     }
 
     $model = $this->getModel('images');
@@ -210,7 +210,7 @@ class JoomGalleryControllerImages extends JoomGalleryController
         $msg = JText::_($publish == 1 ? 'COM_JOOMGALLERY_IMGMAN_MSG_IMAGE_APPROVED' : 'COM_JOOMGALLERY_IMGMAN_MSG_IMAGE_REJECTED');
 
         // Send message about rejection if a message was specified
-        if($task == 'reject' && $message = JRequest::getString('message'))
+        if($task == 'reject' && $message = $this->input->getString('message'))
         {
           $model->sendRejectionMessage($cid[0], $message);
         }
@@ -235,7 +235,7 @@ class JoomGalleryControllerImages extends JoomGalleryController
   {
     $model = $this->getModel('images');
 
-    $cid  = JRequest::getVar('cid', array(), 'post', 'array');
+    $cid  = $this->input->post->get('cid', array(), 'array');
     $unaffected_images = 0;
     foreach($cid as $key => $id)
     {
@@ -247,7 +247,8 @@ class JoomGalleryControllerImages extends JoomGalleryController
       }
     }
 
-    JRequest::setVar('cid', $cid);
+    // TODO Remove this line completely, do we really need this here?
+    // $this->input->set('cid', $cid);
 
     if($unaffected_images)
     {
@@ -291,7 +292,8 @@ class JoomGalleryControllerImages extends JoomGalleryController
    */
   public function edit()
   {
-    $cid = JRequest::getVar('cid', array(), '', 'array');
+    $cid = $this->input->get('cid', array(), 'array');
+
     if(count($cid) <= 1)
     {
       if(count($cid))
@@ -299,26 +301,26 @@ class JoomGalleryControllerImages extends JoomGalleryController
         $exploded = explode(',', $cid[0]);
         if(count($exploded) > 1)
         {
-          JRequest::setVar('cid',   $exploded);
-          JRequest::setVar('view',  'editimages');
+          $this->input->set('cid',   $exploded);
+          $this->input->set('view',  'editimages');
         }
         else
         {
-          JRequest::setVar('view',  'image');
+          $this->input->set('view',  'image');
         }
       }
       else
       {
-        JRequest::setVar('view',  'image');
+        $this->input->set('view',  'image');
       }
     }
     else
     {
-      JRequest::setVar('view',  'editimages');
+      $this->input->set('view',  'editimages');
     }
 
-    JRequest::setVar('layout',  'form');
-    JRequest::setVar('hidemainmenu', 1);
+    $this->input->set('layout',  'form');
+    $this->input->set('hidemainmenu', 1);
 
     parent::display();
   }
@@ -333,7 +335,8 @@ class JoomGalleryControllerImages extends JoomGalleryController
   {
     $model = $this->getModel('image');
 
-    $data = JRequest::get('post', 2);
+    $data         = $this->input->post->get('jform', array(), 'array');
+    $data['cids'] = $this->input->post->getString('cids', NULL);
 
     // Editing more than one image?
     if(isset($data['cids']))
@@ -396,7 +399,7 @@ class JoomGalleryControllerImages extends JoomGalleryController
         }
 
         // Check whether images shall be moved or copied
-        if(isset($cloned_data['catid']) && JRequest::getCmd('movecopy') == 'copy')
+        if(isset($cloned_data['catid']) && $this->input->getCmd('movecopy') == 'copy')
         {
           $orig_img = (array) $this->_ambit->getImgObject($cid);
 
@@ -433,7 +436,7 @@ class JoomGalleryControllerImages extends JoomGalleryController
         }
         else
         {
-          JError::raiseWarning(100, $model->getError());
+          JFactory::getApplication()->enqueueMessage($model->getError(), 'error');
         }
       }
 
@@ -447,25 +450,26 @@ class JoomGalleryControllerImages extends JoomGalleryController
       }
 
       return;
-    }
+    } // Editing more than one image?
 
-    if(JRequest::getCmd('task') == 'save2copy')
+    if($this->input->getCmd('task') == 'save2copy')
     {
       // Reset the ID and then treat the request as for apply.
       // This way a new image will be created and after that
       // it will be displayed right away
-      JRequest::setVar('cid', 0);
-      JRequest::setVar('task', 'apply');
+      $data['cid'] = 0;
+      $this->input->post->set('jform', $data);
+      $this->input->set('task', 'apply');
     }
 
     // Editing only one image
     if($cid = $model->store())
     {
-      if(JRequest::getCmd('task') == 'save2new')
+      if($this->input->getCmd('task') == 'save2new')
       {
         // Reset the ID after storing so that we
         // will be redirected to an empty form
-        JRequest::setVar('task', 'apply');
+        $this->input->set('task', 'apply');
         $cid = 0;
       }
 
@@ -487,11 +491,11 @@ class JoomGalleryControllerImages extends JoomGalleryController
    */
   public function order()
   {
-    $cid = JRequest::getVar('cid', array(), 'post', 'array');
+    $cid = $this->input->post->get('cid', array(), 'array');
 
     // Direction
     $dir  = 1;
-    $task = JRequest::getCmd('task');
+    $task = $this->input->getCmd('task');
     if($task == 'orderup')
     {
       $dir = -1;
@@ -524,8 +528,8 @@ class JoomGalleryControllerImages extends JoomGalleryController
    */
   public function saveOrder()
   {
-    $cid    = JRequest::getVar('cid', array(), 'post', 'array');
-    $order  = JRequest::getVar('order', array (0), 'post', 'array');
+    $cid    = $this->input->post->get('cid', array(), 'array');
+    $order  = $this->input->post->get('order', array(0), 'array');
     $user   = JFactory::getUser();
 
     // Create and load the images table object
@@ -547,7 +551,8 @@ class JoomGalleryControllerImages extends JoomGalleryController
         $row->ordering = $order[$i];
         if(!$row->store())
         {
-          JError::raiseError(500, $this->_db->getErrorMsg());
+          throw new Exception($this->_db->getErrorMsg());
+
           return false;
         }
       }
@@ -555,7 +560,7 @@ class JoomGalleryControllerImages extends JoomGalleryController
 
     if($unchanged_images)
     {
-      JError::raiseNotice(403, JText::plural('COM_JOOMGALLERY_IMGMAN_ERROR_EDITSTATE_NOT_PERMITTED', $unchanged_images));
+      JFactory::getApplication()->enqueueMessage(JText::plural('COM_JOOMGALLERY_IMGMAN_ERROR_EDITSTATE_NOT_PERMITTED', $unchanged_images), 'notice');
     }
 
     $row->reorderAll();
@@ -572,8 +577,8 @@ class JoomGalleryControllerImages extends JoomGalleryController
    */
   public function showmove()
   {
-    JRequest::setVar('view',    'move');
-    JRequest::setVar('hidemainmenu', 1);
+    $this->input->set('view',    'move');
+    $this->input->set('hidemainmenu', 1);
 
     parent::display();
   }
@@ -586,8 +591,8 @@ class JoomGalleryControllerImages extends JoomGalleryController
    */
   public function move()
   {
-    $cid    = JRequest::getVar('cid', array(), 'post', 'array');
-    $catid  = JRequest::getInt('catid');
+    $cid    = $this->input->post->get('cid', array(), 'array');
+    $catid  = $this->input->getInt('catid');
 
     if(!count($cid))
     {
@@ -621,7 +626,7 @@ class JoomGalleryControllerImages extends JoomGalleryController
 
     if($unaffected_images)
     {
-      JError::raiseNotice(403, JText::plural('COM_JOOMGALLERY_IMGMAN_ERROR_MOVE_NOT_PERMITTED', $unaffected_images));
+      JFactory::getApplication()->enqueueMessage(JText::plural('COM_JOOMGALLERY_IMGMAN_ERROR_MOVE_NOT_PERMITTED', $unaffected_images), 'notice');
     }
 
     if($count)
@@ -692,7 +697,7 @@ class JoomGalleryControllerImages extends JoomGalleryController
    */
   public function resetHits()
   {
-    $id = JRequest::getInt('cid');
+    $id = $this->input->getInt('cid');
 
     if(!JFactory::getUser()->authorise('core.edit', _JOOM_OPTION.'.image.'.$id))
     {
@@ -708,7 +713,7 @@ class JoomGalleryControllerImages extends JoomGalleryController
     $row->hits = 0;
     $row->store();
 
-    JRequest::setVar('task', 'apply');
+    $this->input->set('task', 'apply');
     $msg = JText::_('COM_JOOMGALLERY_IMGMAN_MSG_HITS_RESETED');
     $this->setRedirect($this->_ambit->getRedirectUrl(null, $id), $msg);
   }
@@ -721,7 +726,7 @@ class JoomGalleryControllerImages extends JoomGalleryController
    */
   public function resetDownloads()
   {
-    $id = JRequest::getInt('cid');
+    $id = $this->input->getInt('cid');
 
     if(!JFactory::getUser()->authorise('core.edit', _JOOM_OPTION.'.image.'.$id))
     {
@@ -737,7 +742,7 @@ class JoomGalleryControllerImages extends JoomGalleryController
     $row->downloads = 0;
     $row->store();
 
-    JRequest::setVar('task', 'apply');
+    $this->input->set('task', 'apply');
     $msg = JText::_('COM_JOOMGALLERY_IMGMAN_MSG_DOWNLOADS_RESETED');
     $this->setRedirect($this->_ambit->getRedirectUrl(null, $id), $msg);
   }
@@ -750,7 +755,7 @@ class JoomGalleryControllerImages extends JoomGalleryController
    */
   public function resetVotes()
   {
-    $id = JRequest::getInt('cid');
+    $id = $this->input->getInt('cid');
 
     if(!JFactory::getUser()->authorise('core.edit', _JOOM_OPTION.'.image.'.$id))
     {
@@ -771,7 +776,7 @@ class JoomGalleryControllerImages extends JoomGalleryController
           ->delete(_JOOM_TABLE_VOTES)
           ->where('picid = '.$row->id);
     $this->_db->setQuery($query);
-    if(!$this->_db->query())
+    if(!$this->_db->execute())
     {
       JFactory::getApplication()->enqueueMessagge($this->_db->getErrorMsg(), 'error');
 
@@ -779,7 +784,7 @@ class JoomGalleryControllerImages extends JoomGalleryController
     }
     $row->store();
 
-    JRequest::setVar('task', 'apply');
+    $this->input->set('task', 'apply');
     $msg = JText::_('COM_JOOMGALLERY_IMGMAN_MSG_VOTES_RESETED');
     $this->setRedirect($this->_ambit->getRedirectUrl(null, $id), $msg);
   }

--- a/administrator/components/com_joomgallery/controllers/jupload.php
+++ b/administrator/components/com_joomgallery/controllers/jupload.php
@@ -32,7 +32,7 @@ class JoomGalleryControllerJupload extends JoomGalleryController
     parent::__construct();
 
     // Set view
-    JRequest::setVar('view', 'jupload');
+    $this->input->set('view', 'jupload');
   }
 
   /**
@@ -66,6 +66,6 @@ class JoomGalleryControllerJupload extends JoomGalleryController
   {
     require_once JPATH_COMPONENT.'/helpers/upload.php';
     $uploader = new JoomUpload();
-    $uploader->upload(JRequest::getCmd('type', 'java'));
+    $uploader->upload($this->input->getCmd('type', 'java'));
   }
 }

--- a/administrator/components/com_joomgallery/controllers/maintenance.php
+++ b/administrator/components/com_joomgallery/controllers/maintenance.php
@@ -13,6 +13,8 @@
 
 defined('_JEXEC') or die('Direct Access to this location is not allowed.');
 
+use Joomla\Utilities\ArrayHelper;
+
 /**
  * JoomGallery Maintenance Controller
  *
@@ -39,7 +41,7 @@ class JoomGalleryControllerMaintenance extends JoomGalleryController
     }
 
     // Set view
-    JRequest::setVar('view', 'maintenance');
+    $this->input->set('view', 'maintenance');
 
     $this->registerTask('parsefolders',             'check');
     $this->registerTask('checkimages',              'check');
@@ -120,7 +122,7 @@ class JoomGalleryControllerMaintenance extends JoomGalleryController
    */
   public function deleteCompletely()
   {
-    $mainframe  = JFactory::getApplication('administrator');
+    $mainframe  = JFactory::getApplication();
     $categories = $mainframe->getUserState('joom.maintenance.delete.categories');
     $images     = $mainframe->getUserState('joom.maintenance.delete.images');
 
@@ -156,7 +158,7 @@ class JoomGalleryControllerMaintenance extends JoomGalleryController
         // to delete as well as their sub-categories.
         if($row->load($image))
         {
-          JRequest::setVar('cid', array($image));
+          $this->input->post->set('cid', array($image));
           if($model->delete(false))
           {
             $img_count++;
@@ -184,7 +186,7 @@ class JoomGalleryControllerMaintenance extends JoomGalleryController
         // to delete as well as their sub-categories.
         if($row->load($category))
         {
-          JRequest::setVar('cid', array($category));
+          $this->input->post->set('cid', array($category));
           if($model->deletecategory(false, false))
           {
             $cat_count++;
@@ -335,7 +337,7 @@ class JoomGalleryControllerMaintenance extends JoomGalleryController
    */
   public function addOrphan()
   {
-    $tab    = JRequest::getCmd('tab');
+    $tab    = $this->input->getCmd('tab');
 
     if($tab == 'orphans')
     {
@@ -378,7 +380,7 @@ class JoomGalleryControllerMaintenance extends JoomGalleryController
    */
   public function addOrphans()
   {
-    $tab    = JRequest::getCmd('tab');
+    $tab    = $this->input->getCmd('tab');
 
     if($tab == 'orphans')
     {
@@ -389,7 +391,7 @@ class JoomGalleryControllerMaintenance extends JoomGalleryController
       $tab  = '';
     }
 
-    $model  = $this->getModel('maintenance');
+    $model = $this->getModel('maintenance');
     if(!$count = $model->addOrphans())
     {
       $type = 'error';
@@ -421,7 +423,7 @@ class JoomGalleryControllerMaintenance extends JoomGalleryController
    */
   public function addOrphanedFolder()
   {
-    $tab    = JRequest::getCmd('tab');
+    $tab    = $this->input->getCmd('tab');
 
     if($tab == 'folders')
     {
@@ -464,7 +466,7 @@ class JoomGalleryControllerMaintenance extends JoomGalleryController
    */
   public function addOrphanedFolders()
   {
-    $tab    = JRequest::getCmd('tab');
+    $tab    = $this->input->getCmd('tab');
 
     if($tab == 'folders')
     {
@@ -508,7 +510,7 @@ class JoomGalleryControllerMaintenance extends JoomGalleryController
   public function recreate()
   {
     // Load the necessary image IDs
-    $cids = JRequest::getVar('cid', array(), '', 'array');
+    $cids = $this->input->get('cid', array(), 'array');
 
     if(!count($cids))
     {
@@ -516,7 +518,7 @@ class JoomGalleryControllerMaintenance extends JoomGalleryController
       return;
     }
 
-    JArrayHelper::toInteger($cids);
+    ArrayHelper::toInteger($cids);
 
     $query = $this->_db->getQuery(true)
           ->select('refid')
@@ -530,7 +532,7 @@ class JoomGalleryControllerMaintenance extends JoomGalleryController
       return;
     }
 
-    JRequest::setVar('cid', $cids);
+    $this->input->set('cid', $cids);
 
     // Recreate the images
     $model  = $this->getModel('images');
@@ -591,9 +593,9 @@ class JoomGalleryControllerMaintenance extends JoomGalleryController
                 ->where('refid = '.$key)
                 ->where('type = 0');
           $this->_db->setQuery($query);
-          if(!$this->_db->query())
+          if(!$this->_db->execute())
           {
-            JError::raiseWarning(500, $this->_db->getErrorMsg());
+            JFactory::getApplication()->enqueueMessage($this->_db->getErrorMsg(), 'error');
           }
         }
       }
@@ -798,7 +800,7 @@ class JoomGalleryControllerMaintenance extends JoomGalleryController
   {
     $model = $this->getModel('maintenancecheck');
 
-    $task   = JRequest::getCmd('task');
+    $task   = $this->input->getCmd('task');
 
     require_once JPATH_COMPONENT.'/helpers/refresher.php';
 

--- a/administrator/components/com_joomgallery/controllers/migration.php
+++ b/administrator/components/com_joomgallery/controllers/migration.php
@@ -36,7 +36,7 @@ class JoomGalleryControllerMigration extends JoomGalleryController
     require_once JPATH_COMPONENT.'/helpers/migration.php';
 
     // Set view
-    JRequest::setVar('view', 'migration');
+    $this->input->set('view', 'migration');
 
     // Register tasks
     $this->registerTask('check',  'migrate');
@@ -54,8 +54,8 @@ class JoomGalleryControllerMigration extends JoomGalleryController
   {
     jimport('joomla.filesystem.file');
 
-    $migration = JRequest::getCmd('migration', '');
-    $task      = JRequest::getCmd('task');
+    $migration = $this->input->getCmd('migration', '');
+    $task      = $this->input->getCmd('task');
 
     if(!JFile::exists(JPATH_COMPONENT.'/helpers/migration/migrate'.$migration.'.php'))
     {

--- a/administrator/components/com_joomgallery/controllers/nametags.php
+++ b/administrator/components/com_joomgallery/controllers/nametags.php
@@ -60,7 +60,7 @@ class JoomGalleryControllerNametags extends JoomGalleryController
           ->where('(u.id IS NULL OR i.id IS NULL)');
     $this->_db->setQuery($query);
 
-    if(!$this->_db->query())
+    if(!$this->_db->execute())
     {
       $this->setRedirect($this->_ambit->getRedirectUrl('maintenance&tab=nametags'), $this->_db->getErrorMsg(), 'error');
       return;

--- a/administrator/components/com_joomgallery/controllers/upload.php
+++ b/administrator/components/com_joomgallery/controllers/upload.php
@@ -32,7 +32,7 @@ class JoomGalleryControllerUpload extends JoomGalleryController
     parent::__construct();
 
     // Set view
-    JRequest::setVar('view', 'upload');
+    $this->input->set('view', 'upload');
   }
 
   /**
@@ -66,13 +66,13 @@ class JoomGalleryControllerUpload extends JoomGalleryController
   {
     require_once JPATH_COMPONENT.'/helpers/upload.php';
     $uploader = new JoomUpload();
-    if($uploader->upload(JRequest::getCmd('type', 'single')))
+    if($uploader->upload($this->input->getCmd('type', 'single')))
     {
       $msg  = JText::_('COM_JOOMGALLERY_UPLOAD_MSG_SUCCESSFULL');
       $url  = $this->_ambit->getRedirectUrl();
 
       // Set custom redirect if we are asked for that
-      if($redirect = JRequest::getVar('redirect', '', '', 'base64'))
+      if($redirect = $this->input->getBase64('redirect', ''))
       {
         $url_decoded  = base64_decode($redirect);
         if(JURI::isInternal($url))

--- a/administrator/components/com_joomgallery/controllers/votes.php
+++ b/administrator/components/com_joomgallery/controllers/votes.php
@@ -44,7 +44,7 @@ class JoomGalleryControllerVotes extends JoomGalleryController
           ->set('imgvotesum = 0');
     $this->_db->setQuery($query);
 
-    if(!$this->_db->query())
+    if(!$this->_db->execute())
     {
       $this->setRedirect($this->_ambit->getRedirectUrl('maintenance&tab=votes'), $this->_db->getErrorMsg(), 'error');
 
@@ -73,7 +73,7 @@ class JoomGalleryControllerVotes extends JoomGalleryController
           ->where('(u.id IS NULL OR i.id IS NULL)');
     $this->_db->setQuery($query);
 
-    if(!$this->_db->query())
+    if(!$this->_db->execute())
     {
       $this->setRedirect($this->_ambit->getRedirectUrl('maintenance&tab=votes'), $this->_db->getErrorMsg(), 'error');
       return;
@@ -95,7 +95,7 @@ class JoomGalleryControllerVotes extends JoomGalleryController
           ->set('p.imgvotesum  = ('.$sum_subquery.')');
     $this->_db->setQuery($query);
 
-    if(!$this->_db->query())
+    if(!$this->_db->execute())
     {
       $this->setRedirect($this->_ambit->getRedirectUrl('maintenance&tab=votes'), $this->_db->getErrorMsg(), 'error');
 

--- a/administrator/components/com_joomgallery/helpers/ambit.php
+++ b/administrator/components/com_joomgallery/helpers/ambit.php
@@ -148,7 +148,7 @@ class JoomAmbit extends JObject
     jimport('joomla.filesystem.folder');
 
     $config     = JoomConfig::getInstance();
-    $mainframe  = JFactory::getApplication('administrator');
+    $mainframe  = JFactory::getApplication();
 
     // Fill all variables
     $this->icon_url   = JURI::root().'media/joomgallery/images/';
@@ -286,8 +286,10 @@ class JoomAmbit extends JObject
 
     if(is_null($controller))
     {
-      $url .= '&controller='.JRequest::getCmd('controller');
-      if(!is_null($id) && JRequest::getCmd('task') == 'apply')
+      $input = JFactory::getApplication()->input;
+
+      $url .= '&controller='.$input->getCmd('controller');
+      if(!is_null($id) && $input->getCmd('task') == 'apply')
       {
         $url .= '&task=edit&'.$key.'='.$id;
       }
@@ -317,7 +319,7 @@ class JoomAmbit extends JObject
     $types = array('thumb_path', 'thumb_url', 'img_path', 'img_url', 'orig_path', 'orig_url');
     if(!in_array($type, $types))
     {
-      JError::raiseError(500, JText::sprintf('Wrong image type: %s', $type));
+      throw new UnexpectedValueException(JText::sprintf('Wrong image type: %s', $type));
     }
 
     if(!is_object($img))
@@ -396,7 +398,7 @@ class JoomAmbit extends JObject
 
       if(!$row->load($id))
       {
-        JError::raiseError(500, JText::sprintf('Image with ID %d not found', $id));
+        throw new RuntimeException(JText::sprintf('Image with ID %d not found', $id));
       }
 
       $properties   = $row->getProperties();

--- a/administrator/components/com_joomgallery/helpers/config.php
+++ b/administrator/components/com_joomgallery/helpers/config.php
@@ -388,7 +388,7 @@ class JoomConfig extends JObject
       $db->setQuery($query, 0, 1);
       if(!$properties = $db->loadAssoc())
       {
-        JError::raiseError(500, JText::_('Error loading config data'));
+        throw new RuntimeException(JText::_('Error loading config data'));
       }
 
       $this->_id = $properties['id'];

--- a/administrator/components/com_joomgallery/helpers/extensions.php
+++ b/administrator/components/com_joomgallery/helpers/extensions.php
@@ -226,7 +226,7 @@ class JoomExtensions
       {
         $version_from_xml = false;
 
-        $mainframe = JFactory::getApplication('administrator');
+        $mainframe = JFactory::getApplication();
         if(!$version = $mainframe->getUserState('joom.version.string'))
         {
           $extensions = JoomExtensions::getInstalledExtensions();

--- a/administrator/components/com_joomgallery/helpers/file.php
+++ b/administrator/components/com_joomgallery/helpers/file.php
@@ -650,7 +650,7 @@ class JoomFile
         }
         break;
       default:
-        JError::raiseError(500, JText::_('COM_JOOMGALLERY_UPLOAD_UNSUPPORTED_RESIZING_METHOD'));
+        throw new UnexpectedValueException(JText::_('COM_JOOMGALLERY_UPLOAD_UNSUPPORTED_RESIZING_METHOD'));
         break;
     }
 

--- a/administrator/components/com_joomgallery/helpers/helper.php
+++ b/administrator/components/com_joomgallery/helpers/helper.php
@@ -30,7 +30,7 @@ class JoomHelper
    */
   public static function addSubmenu()
   {
-    $current_controller = JRequest::getCmd('controller', 'control');
+    $current_controller = JFactory::getApplication()->input->getCmd('controller', 'control');
 
     $controllers = array( 'control'     => JText::_('COM_JOOMGALLERY_CONTROL_PANEL'),
                           'categories'  => JText::_('COM_JOOMGALLERY_CATEGORY_MANAGER'),

--- a/administrator/components/com_joomgallery/helpers/html/joomgallery.php
+++ b/administrator/components/com_joomgallery/helpers/html/joomgallery.php
@@ -83,11 +83,8 @@ abstract class JHtmlJoomGallery
     }
 
     $config     = JoomConfig::getInstance();
-    $dispatcher = JDispatcher::getInstance();
-
     $realname   = $config->get('jg_realname') ? true : false;
-
-    $plugins    = $dispatcher->trigger('onJoomDisplayUser', array($userId, $realname, $context));
+    $plugins    = JFactory::getApplication()->triggerEvent('onJoomDisplayUser', array($userId, $realname, $context));
 
     foreach($plugins as $plugin)
     {
@@ -689,12 +686,8 @@ abstract class JHtmlJoomGallery
         }
         break;
       default: // Plugins
-        if(!isset($loaded[12]))
-        {
-          $loaded[12] = JDispatcher::getInstance();
-        }
         $link = '';
-        $loaded[12]->trigger('onJoomOpenImage', array(&$link, $image, $img_url, $group, $type, $open));
+        JFactory::getApplication()->triggerEvent('onJoomOpenImage', array(&$link, $image, $img_url, $group, $type, $open));
         if(!$link)
         {
           // Fallback to new window

--- a/administrator/components/com_joomgallery/helpers/html/joomgallery.php
+++ b/administrator/components/com_joomgallery/helpers/html/joomgallery.php
@@ -13,6 +13,8 @@
 
 defined( '_JEXEC' ) or die( 'Direct Access to this location is not allowed.' );
 
+use Joomla\Utilities\ArrayHelper;
+
 /**
  * Utility class for creating HTML Grids
  *
@@ -377,7 +379,7 @@ abstract class JHtmlJoomGallery
     $config   = JoomConfig::getInstance();
     $ambit    = JoomAmbit::getInstance();
     $user     = JFactory::getUser();
-    $view     = JRequest::getCmd('view');
+    $view     = JFactory::getApplication()->input->getCmd('view');
 
     $html = '';
 
@@ -553,7 +555,7 @@ abstract class JHtmlJoomGallery
       }
       else
       {
-        if(JRequest::getCmd('view') == 'detail')
+        if(JFactory::getApplication()->input->getCmd('view') == 'detail')
         {
           $type = 'orig';
         }
@@ -1433,7 +1435,7 @@ abstract class JHtmlJoomGallery
    */
   public static function approved($states, $value, $i, $prefix = '', $enabled = true, $id = 0, $owner = 0, $translate = true, $checkbox = 'cb')
   {
-    $state = JArrayHelper::getValue($states, (int) $value, $states[0]);
+    $state = ArrayHelper::getValue($states, (int) $value, $states[0]);
     $task = array_key_exists('task', $state) ? $state['task'] : $state[0];
     $text = array_key_exists('text', $state) ? $state['text'] : (array_key_exists(1, $state) ? $state[1] : '');
     $active_title = array_key_exists('active_title', $state) ? $state['active_title'] : (array_key_exists(2, $state) ? $state[2] : '');

--- a/administrator/components/com_joomgallery/helpers/html/joomselect.php
+++ b/administrator/components/com_joomgallery/helpers/html/joomselect.php
@@ -391,7 +391,7 @@ abstract class JHtmlJoomSelect
 
     // Load plugins in order to search for additional OpenImage plugins
     JPluginHelper::importPlugin('joomgallery');
-    $plugins = JDispatcher::getInstance()->trigger('onJoomOpenImageGetName');
+    $plugins = JFactory::getApplication()->triggerEvent('onJoomOpenImageGetName');
 
     foreach($plugins as $plugin)
     {

--- a/administrator/components/com_joomgallery/helpers/migration.php
+++ b/administrator/components/com_joomgallery/helpers/migration.php
@@ -13,6 +13,8 @@
 
 defined('_JEXEC') or die('Direct Access to this location is not allowed.');
 
+use Joomla\Utilities\ArrayHelper;
+
 /**
  * Helper class for migration procedures
  *
@@ -152,17 +154,17 @@ abstract class JoomMigration
 
     // Connect to second database if necessary
     $db = $this->getStateFromRequest('db2', 'db', array(), 'array');
-    if(JArrayHelper::getValue($db, 'enabled', false, 'boolean'))
+    if(ArrayHelper::getValue($db, 'enabled', false, 'boolean'))
     {
-      $driver   = JArrayHelper::getValue($db, 'db_type', 'mysqli', 'string');
-      $host     = JArrayHelper::getValue($db, 'db_host', 'localhost', 'string');
-      $name     = JArrayHelper::getValue($db, 'db_name', '', 'string');
-      $user     = JArrayHelper::getValue($db, 'db_user', '', 'string');
-      $password = JArrayHelper::getValue($db, 'db_pass', '', 'string');
+      $driver   = ArrayHelper::getValue($db, 'db_type', 'mysqli', 'string');
+      $host     = ArrayHelper::getValue($db, 'db_host', 'localhost', 'string');
+      $name     = ArrayHelper::getValue($db, 'db_name', '', 'string');
+      $user     = ArrayHelper::getValue($db, 'db_user', '', 'string');
+      $password = ArrayHelper::getValue($db, 'db_pass', '', 'string');
       $prefix   = $this->getStateFromRequest('prefix', 'prefix', '', 'cmd');
       if(!$prefix)
       {
-        $prefix   = JArrayHelper::getValue($db, 'prefix', '', 'cmd');
+        $prefix   = ArrayHelper::getValue($db, 'prefix', '', 'cmd');
         $this->setState('prefix', $prefix);
       }
 
@@ -414,7 +416,7 @@ abstract class JoomMigration
    * @param   string  $request  The name of the variable passed in a request
    * @param   string  $default  The default value for the variable if not found
    * @param   string  $type     Filter for the variable, for valid values see {@link JFilterInput::clean()}
-   * @return  The requested state
+   * @return  mixed The requested state
    * @since   3.1
    */
   public function getStateFromRequest($key, $request, $default = null, $type = 'none')
@@ -480,11 +482,11 @@ abstract class JoomMigration
       $data->db = array();
       $db = (array) $this->getState('db2', array());
       $data->db['enabled'] = $data->database;
-      $data->db['db_type'] = JArrayHelper::getValue($db, 'db_type', 'mysqli', 'string');
-      $data->db['db_host'] = JArrayHelper::getValue($db, 'db_host', 'localhost', 'string');
-      $data->db['db_user'] = JArrayHelper::getValue($db, 'db_user', '', 'string');
-      $data->db['db_pass'] = JArrayHelper::getValue($db, 'db_pass', '', 'string');
-      $data->db['db_name'] = JArrayHelper::getValue($db, 'db_name', '', 'string');
+      $data->db['db_type'] = ArrayHelper::getValue($db, 'db_type', 'mysqli', 'string');
+      $data->db['db_host'] = ArrayHelper::getValue($db, 'db_host', 'localhost', 'string');
+      $data->db['db_user'] = ArrayHelper::getValue($db, 'db_user', '', 'string');
+      $data->db['db_pass'] = ArrayHelper::getValue($db, 'db_pass', '', 'string');
+      $data->db['db_name'] = ArrayHelper::getValue($db, 'db_name', '', 'string');
       $data->db['prefix'] = $this->getState('prefix');
       $form->bind($data);
 
@@ -695,7 +697,7 @@ abstract class JoomMigration
               ->select('COUNT(*)')
               ->from($table);
         $db->setQuery($query);
-        
+
         $count = $db->loadResult();
 
         if($count == 0)
@@ -801,7 +803,7 @@ abstract class JoomMigration
     }
     else
     {
-      $check['title'] = '<span style="color:#f30; font-weight:bold;">'.Text::_('COM_JOOMGALLERY_MIGMAN_ROOT_ASSET_DOES_NOT_EXIST').'</span> '.JText::_('COM_JOOMGALLERY_MIGMAN_PLEASE_REINSTALL');
+      $check['title'] = '<span style="color:#f30; font-weight:bold;">'.JText::_('COM_JOOMGALLERY_MIGMAN_ROOT_ASSET_DOES_NOT_EXIST').'</span> '.JText::_('COM_JOOMGALLERY_MIGMAN_PLEASE_REINSTALL');
       $check['state'] = false;
       $ready = false;
     }

--- a/administrator/components/com_joomgallery/helpers/openimageplugin.php
+++ b/administrator/components/com_joomgallery/helpers/openimageplugin.php
@@ -13,6 +13,8 @@
 
 defined('_JEXEC') or die('Direct Access to this location is not allowed.');
 
+use Joomla\Utilities\ArrayHelper;
+
 jimport('joomla.plugin.plugin');
 
 /**
@@ -115,7 +117,7 @@ abstract class JoomOpenImagePlugin extends JPlugin
       return;
     }
 
-    $attribs = JArrayHelper::toString($attribs);
+    $attribs = ArrayHelper::toString($attribs);
 
     // Remove the last quotation marks and create the tag
     $link = $href.'" '.substr($attribs, 0, -1);

--- a/administrator/components/com_joomgallery/helpers/refresher.php
+++ b/administrator/components/com_joomgallery/helpers/refresher.php
@@ -103,7 +103,7 @@ class JoomRefresher extends JObject
    */
   public function __construct($params = array())
   {
-    $this->_mainframe = JFactory::getApplication('administrator');
+    $this->_mainframe = JFactory::getApplication();
 
     if(isset($params['controller']))
     {
@@ -111,7 +111,7 @@ class JoomRefresher extends JObject
     }
     else
     {
-      $this->_controller    = JRequest::getCmd('controller');
+      $this->_controller    = $this->_mainframe->input->getCmd('controller');
     }
 
     if(isset($params['task']))
@@ -120,7 +120,7 @@ class JoomRefresher extends JObject
     }
     else
     {
-      $this->_task          = JRequest::getCmd('task');
+      $this->_task          = $this->_mainframe->input->getCmd('task');
     }
 
     if(isset($params['msg']))

--- a/administrator/components/com_joomgallery/joomgallery.php
+++ b/administrator/components/com_joomgallery/joomgallery.php
@@ -15,11 +15,13 @@ defined('_JEXEC') or die('Direct Access to this location is not allowed.');
 
 JHtml::_('behavior.tabstate');
 
-if(version_compare(JVERSION, '4.0', 'ge') || version_compare(JVERSION, '3.0', 'lt'))
+if(version_compare(JVERSION, '5.0', 'ge') || version_compare(JVERSION, '3.0', 'lt'))
 {
   JToolBarHelper::title('JoomGallery');
 
-  return JError::raiseWarning(500, 'JoomGallery 3.x is only compatible to Joomla! 3.x');
+  JFactory::getApplication()->enqueueMessage('JoomGallery 4.x is only compatible to Joomla! 4.x', 'error');
+
+  return;
 }
 
 // Require the base controller and the defines
@@ -29,17 +31,22 @@ require_once(JPATH_COMPONENT.'/includes/defines.php');
 // Access check
 if(!JFactory::getUser()->authorise('core.manage', _JOOM_OPTION))
 {
-  return JError::raiseWarning(404, JText::_('JERROR_ALERTNOAUTHOR'));
+  JFactory::getApplication()->enqueueMessage(JText::_('JERROR_ALERTNOAUTHOR'), 'error');
+
+  return;
 }
 
 // Enable JoomGallery plugins
 JPluginHelper::importPlugin('joomgallery');
 
+$input = JFactory::getApplication()->input;
+
 // Require specific controller if requested
-if($controller = JRequest::getCmd('controller', 'control'))
+if($controller = $input->getCmd('controller', 'control'))
 {
-  $format = JRequest::getCmd('format', 'html');
-  $path = JPATH_COMPONENT.'/controllers/'.$controller.(($format != 'html') ?  '.'.$format : '').'.php';
+  $format = $input->getCmd('format', 'html');
+  $path   = JPATH_COMPONENT.'/controllers/'.$controller.(($format != 'html') ?  '.'.$format : '').'.php';
+
   if(file_exists($path))
   {
     require_once $path;

--- a/administrator/components/com_joomgallery/model.php
+++ b/administrator/components/com_joomgallery/model.php
@@ -13,8 +13,6 @@
 
 defined('_JEXEC') or die('Direct Access to this location is not allowed.');
 
-jimport( 'joomla.application.component.model');
-
 /**
  * JoomGallery Parent Model
  *
@@ -29,7 +27,7 @@ class JoomGalleryModel extends JModelLegacy
    * @access  protected
    * @var     object
    */
-  var $_mainframe;
+  protected $_mainframe;
 
   /**
    * JoomConfig object
@@ -37,7 +35,7 @@ class JoomGalleryModel extends JModelLegacy
    * @access  protected
    * @var     object
    */
-  var $_config;
+  protected $_config;
 
   /**
    * JoomAmbit object
@@ -45,7 +43,7 @@ class JoomGalleryModel extends JModelLegacy
    * @access  protected
    * @var     object
    */
-  var $_ambit;
+  protected $_ambit;
 
   /**
    * JUser object, holds the current user data
@@ -53,7 +51,7 @@ class JoomGalleryModel extends JModelLegacy
    * @access  protected
    * @var     object
    */
-  var $_user;
+  protected $_user;
 
   /**
    * Constructor
@@ -68,8 +66,7 @@ class JoomGalleryModel extends JModelLegacy
 
     $this->_ambit     = JoomAmbit::getInstance();
     $this->_config    = JoomConfig::getInstance();
-
-    $this->_mainframe = JFactory::getApplication('administrator');
+    $this->_mainframe = JFactory::getApplication();
     $this->_user      = JFactory::getUser();
   }
 }

--- a/administrator/components/com_joomgallery/models/categories.php
+++ b/administrator/components/com_joomgallery/models/categories.php
@@ -13,6 +13,8 @@
 
 defined('_JEXEC') or die('Direct Access to this location is not allowed.');
 
+use Joomla\Utilities\ArrayHelper;
+
 /**
  * Categories model
  *
@@ -228,7 +230,7 @@ class JoomGalleryModelCategories extends JoomGalleryModel
   protected function loadForm($name, $source = null, $options = array(), $clear = false, $xpath = false)
   {
     // Handle the optional arguments.
-    $options['control'] = JArrayHelper::getValue($options, 'control', false);
+    $options['control'] = ArrayHelper::getValue($options, 'control', false);
 
     // Get the form.
     JForm::addFormPath(JPATH_COMPONENT . '/models/forms');
@@ -656,7 +658,7 @@ class JoomGalleryModelCategories extends JoomGalleryModel
   public function getOrderedCategories($categories, $ordering = 'lft', $direction = 'ASC')
   {
     // Sanitise variables
-    JArrayHelper::toInteger($categories);
+    ArrayHelper::toInteger($categories);
     if(!in_array($ordering, $this->filter_fields))
     {
       $ordering = 'lft';
@@ -687,7 +689,7 @@ class JoomGalleryModelCategories extends JoomGalleryModel
    */
   public function publish($cid, $publish = 1, $task = 'publish')
   {
-    JArrayHelper::toInteger($cid);
+    ArrayHelper::toInteger($cid);
     $publish = intval($publish);
     $count = count($cid);
 
@@ -909,7 +911,7 @@ class JoomGalleryModelCategories extends JoomGalleryModel
    * @param   string  $default    The default value for the variable if not found (optional)
    * @param   string  $type       Filter for the variable, for valid values see {@link JFilterInput::clean()} (optional)
    * @param   boolean $resetPage  If true, the limitstart in request is set to zero if the state has changed
-   * @return  The requested user state
+   * @return  mixed  The request user state
    * @since   2.0
    */
   public function getUserStateFromRequest($key, $request, $default = null, $type = 'none', $resetPage = true)
@@ -918,11 +920,11 @@ class JoomGalleryModelCategories extends JoomGalleryModel
 
     $old_state = $app->getUserState($key);
     $cur_state = (!is_null($old_state)) ? $old_state : $default;
-    $new_state = JRequest::getVar($request, null, 'default', $type);
+    $new_state = $this->_mainframe->input->get($request, null, $type);
 
     if($cur_state != $new_state && !is_null($new_state) && !is_null($old_state) && $resetPage)
     {
-      JRequest::setVar('limitstart', 0);
+      $this->_mainframe->input->set('limitstart', 0);
     }
 
     // Save the new value only if it was set in this request.

--- a/administrator/components/com_joomgallery/models/category.php
+++ b/administrator/components/com_joomgallery/models/category.php
@@ -168,23 +168,8 @@ class JoomGalleryModelCategory extends JoomGalleryModel
     // Import the appropriate plugin group
     JPluginHelper::importPlugin($group);
 
-    // Get the dispatcher
-    $dispatcher = JDispatcher::getInstance();
-
     // Trigger the form preparation event
-    $results = $dispatcher->trigger('onContentPrepareForm', array($form, $data));
-
-    // Check for errors encountered while preparing the form
-    if(count($results) && in_array(false, $results, true))
-    {
-      // Get the last error
-      $error = $dispatcher->getError();
-
-      if(!($error instanceof Exception))
-      {
-        throw new Exception($error);
-      }
-    }
+    $this->_mainframe->triggerEvent('onContentPrepareForm', array($form, $data));
   }
 
   /**

--- a/administrator/components/com_joomgallery/models/category.php
+++ b/administrator/components/com_joomgallery/models/category.php
@@ -13,7 +13,7 @@
 
 defined('_JEXEC') or die('Direct Access to this location is not allowed.');
 
-jimport('joomla.form.form');
+use Joomla\Utilities\ArrayHelper;
 
 /**
  * Category model
@@ -33,7 +33,7 @@ class JoomGalleryModelCategory extends JoomGalleryModel
   {
     parent::__construct();
 
-    $array = JRequest::getVar('cid',  0, '', 'array');
+    $array = $this->_mainframe->input->get('cid', array(0), 'array');
     $this->setId((int)$array[0]);
   }
 
@@ -129,7 +129,7 @@ class JoomGalleryModelCategory extends JoomGalleryModel
     JForm::addFormPath(JPATH_COMPONENT.'/models/forms');
     JForm::addFieldPath(JPATH_COMPONENT.'/models/fields');
 
-    $form = JForm::getInstance(_JOOM_OPTION.'.category', 'category');
+    $form = JForm::getInstance(_JOOM_OPTION.'.category', 'category', array('control' => 'jform'));
     if(empty($form))
     {
       return false;
@@ -198,7 +198,8 @@ class JoomGalleryModelCategory extends JoomGalleryModel
     $row = $this->getTable('joomgallerycategories');
 
     // Get all necessary data from the post
-    $data     = JRequest::get('post', 2);
+    $data = $this->_mainframe->input->post->get('jform', array(), 'array');
+
     $params   = isset($data['params']) ? $data['params'] : array();
 
     // Creating a main category means creating
@@ -241,7 +242,7 @@ class JoomGalleryModelCategory extends JoomGalleryModel
       $isNew = true;
 
       // Alter the name and the alias //for save as copy
-      //if(JRequest::getCmd('task') == 'save2copy')
+      //if($this->_mainframe->input->getCmd('task') == 'save2copy')
       //{
         list($title, $alias) = $this->generateNewTitle($data['parent_id'], $data['alias'], $data['name']);
         $data['name']  = $title;
@@ -429,7 +430,7 @@ class JoomGalleryModelCategory extends JoomGalleryModel
 
         /*if(!$row->store())
         {
-            JError::raiseError(100, $row->getError());
+            throw new RuntimeException($row->getError());
             return false;
         }*/
         $this->_mainframe->enqueueMessage(JText::_('COM_JOOMGALLERY_COMMON_MSG_NOT_ALLOWED_STORE_IMAGE_IN_CATEGORY'), 'notice');
@@ -558,7 +559,7 @@ class JoomGalleryModelCategory extends JoomGalleryModel
   {
     // Sanitize user IDs
     $pks = array_unique($pks);
-    JArrayHelper::toInteger($pks);
+    ArrayHelper::toInteger($pks);
 
     // Remove any values of zero
     if(array_search(0, $pks, true))
@@ -575,7 +576,7 @@ class JoomGalleryModelCategory extends JoomGalleryModel
 
     $done = false;
 
-    if($cmd = JArrayHelper::getValue($commands, 'move_copy'))
+    if($cmd = ArrayHelper::getValue($commands, 'move_copy'))
     {
       if($cmd == 'c')
       {
@@ -1100,7 +1101,7 @@ class JoomGalleryModelCategory extends JoomGalleryModel
 
     if($this->_db->getErrorNum())
     {
-      JError::raiseWarning(500, $this->_db->getErrorMsg());
+      $this->_mainframe->enqueueMessage($this->_db->getErrorMsg(), 'error');
     }
 
     // Nothing found, return
@@ -1122,7 +1123,7 @@ class JoomGalleryModelCategory extends JoomGalleryModel
       $row->catpath = $catpath;
       if(!$row->store())
       {
-        JError::raiseError(500, $row->getError());
+        throw new RuntimeException($row->getError());
       }
     }
 
@@ -1208,7 +1209,7 @@ class JoomGalleryModelCategory extends JoomGalleryModel
     if($return !== true)
     {
       // If not successfull
-      JError::raiseWarning(100, $return);
+      $this->_mainframe->enqueueMessage($return, 'error');
       return false;
     }
     else
@@ -1219,7 +1220,7 @@ class JoomGalleryModelCategory extends JoomGalleryModel
       {
         // If not successful
         JFolder::move($orig_dest, $orig_src);
-        JError::raiseWarning(100, $return);
+        $this->_mainframe->enqueueMessage($return, 'error');
         return false;
       }
       else
@@ -1231,7 +1232,7 @@ class JoomGalleryModelCategory extends JoomGalleryModel
           // If not successful
           JFolder::move($orig_dest, $orig_src);
           JFolder::move($img_dest, $img_src);
-          JError::raiseWarning(100, $return);
+          $this->_mainframe->enqueueMessage($return, 'error');
           return false;
         }
       }

--- a/administrator/components/com_joomgallery/models/comments.php
+++ b/administrator/components/com_joomgallery/models/comments.php
@@ -13,6 +13,8 @@
 
 defined('_JEXEC') or die('Direct Access to this location is not allowed.');
 
+use Joomla\Utilities\ArrayHelper;
+
 /**
  * Comments model
  *
@@ -199,7 +201,7 @@ class JoomGalleryModelComments extends JoomGalleryModel
   protected function loadForm($name, $source = null, $options = array(), $clear = false, $xpath = false)
   {
     // Handle the optional arguments.
-    $options['control'] = JArrayHelper::getValue($options, 'control', false);
+    $options['control'] = ArrayHelper::getValue($options, 'control', false);
 
     // Get the form.
     JForm::addFormPath(JPATH_COMPONENT . '/models/forms');
@@ -459,7 +461,7 @@ class JoomGalleryModelComments extends JoomGalleryModel
    */
   public function delete()
   {
-    $cids = JRequest::getVar('cid', array(0), 'post', 'array');
+    $cids = $this->_mainframe->input->post->get('cid', array(0), 'array');
 
     $row = $this->getTable('joomgallerycomments');
 
@@ -491,7 +493,7 @@ class JoomGalleryModelComments extends JoomGalleryModel
    */
   public function publish($cid, $publish = 1, $task = 'publish')
   {
-    JArrayHelper::toInteger($cid);
+    ArrayHelper::toInteger($cid);
     $cids = implode(',', $cid);
 
     $column = 'approved';
@@ -505,7 +507,7 @@ class JoomGalleryModelComments extends JoomGalleryModel
           ->set($column.' = '.(int) $publish)
           ->where('cmtid IN ('.$cids.' )');
     $this->_db->setQuery($query);
-    if(!$this->_db->query())
+    if(!$this->_db->execute())
     {
       return false;
     }
@@ -562,7 +564,7 @@ class JoomGalleryModelComments extends JoomGalleryModel
    * @param   string  $default    The default value for the variable if not found (optional)
    * @param   string  $type       Filter for the variable, for valid values see {@link JFilterInput::clean()} (optional)
    * @param   boolean $resetPage  If true, the limitstart in request is set to zero if the state has changed
-   * @return  The requested user state
+   * @return  mixed The requested user state
    * @since   2.0
    */
   public function getUserStateFromRequest($key, $request, $default = null, $type = 'none', $resetPage = true)
@@ -571,11 +573,11 @@ class JoomGalleryModelComments extends JoomGalleryModel
 
     $old_state = $app->getUserState($key);
     $cur_state = (!is_null($old_state)) ? $old_state : $default;
-    $new_state = JRequest::getVar($request, null, 'default', $type);
+    $new_state = $app->input->get($request, null, $type);
 
     if($cur_state != $new_state && !is_null($new_state) && !is_null($old_state) && $resetPage)
     {
-      JRequest::setVar('limitstart', 0);
+      $app->input->set('limitstart', 0);
     }
 
     // Save the new value only if it was set in this request.

--- a/administrator/components/com_joomgallery/models/config.php
+++ b/administrator/components/com_joomgallery/models/config.php
@@ -122,7 +122,7 @@ class JoomGalleryModelConfig extends JoomGalleryModel
           ->from(_JOOM_TABLE_CONFIG.' AS c')
           ->from('#__usergroups AS g')
           ->where('c.group_id = g.id')
-          ->where('c.id = '.JRequest::getInt('id'));
+          ->where('c.id = '.$this->_mainframe->input->getInt('id'));
     $this->_db->setQuery($query);
 
     return $this->_db->loadResult();

--- a/administrator/components/com_joomgallery/models/configs.php
+++ b/administrator/components/com_joomgallery/models/configs.php
@@ -201,7 +201,7 @@ class JoomGalleryModelConfigs extends JoomGalleryModel
     {
       $options = $this->_db->loadObjectList();
     }
-    catch(DatabaseException $e)
+    catch(JDatabaseExceptionExecuting $e)
     {
       $this->setError($this->_db->getErrorMsg());
 
@@ -241,7 +241,7 @@ class JoomGalleryModelConfigs extends JoomGalleryModel
     {
       $subgroups = $this->_db->loadResult();
     }
-    catch(DatabaseException $e)
+    catch(JDatabaseExceptionExecuting $e)
     {
       $this->setError($e->getMessage());
 
@@ -273,7 +273,7 @@ class JoomGalleryModelConfigs extends JoomGalleryModel
     {
       $subgroups = $this->_db->loadObjectList();
     }
-    catch(DatabaseException $e)
+    catch(JDatabaseExceptionExecuting $e)
     {
       $this->setError($e->getMessage());
 
@@ -474,7 +474,7 @@ class JoomGalleryModelConfigs extends JoomGalleryModel
     {
       $ids = $this->_db->loadColumn();
     }
-    catch(DatabaseException $e)
+    catch(JDatabaseExceptionExecuting $e)
     {
       $this->setError($this->_db->getErrorMsg());
 
@@ -533,7 +533,7 @@ class JoomGalleryModelConfigs extends JoomGalleryModel
    * @param   string  The default value for the variable if not found. Optional.
    * @param   string  Filter for the variable, for valid values see {@link JFilterInput::clean()}. Optional.
    * @param   boolean If true, the limitstart in request is set to zero
-   * @return  The requested user state.
+   * @return  mixed The requested user state.
    * @since   2.0
    */
   public function getUserStateFromRequest($key, $request, $default = null, $type = 'none', $resetPage = true)
@@ -541,10 +541,10 @@ class JoomGalleryModelConfigs extends JoomGalleryModel
     $app = JFactory::getApplication();
     $old_state = $app->getUserState($key);
     $cur_state = (!is_null($old_state)) ? $old_state : $default;
-    $new_state = JRequest::getVar($request, null, 'default', $type);
+    $new_state = $this->_mainframe->input->get($request, null, $type);
 
     if (($cur_state != $new_state) && ($resetPage)){
-      JRequest::setVar('limitstart', 0);
+      $this->_mainframe->input->set('limitstart', 0);
     }
 
     // Save the new value only if it was set in this request.

--- a/administrator/components/com_joomgallery/models/editimages.php
+++ b/administrator/components/com_joomgallery/models/editimages.php
@@ -13,8 +13,6 @@
 
 defined('_JEXEC') or die('Direct Access to this location is not allowed.');
 
-jimport('joomla.form.form');
-
 /**
  * Edit multiple images model
  *
@@ -38,7 +36,7 @@ class JoomGalleryModelEditimages extends JoomGalleryModel
    */
   protected function _buildQuery()
   {
-    $cid = JRequest::getVar('cid', array(), '', 'array');
+    $cid = $this->_mainframe->input->get('cid', array(), 'array');
 
     $query = $this->_db->getQuery(true)
           ->select('a.*, c.cid AS category_id, c.name AS category_name, g.title AS groupname')
@@ -80,7 +78,8 @@ class JoomGalleryModelEditimages extends JoomGalleryModel
     JForm::addFieldPath(JPATH_COMPONENT.'/models/fields');
     JForm::addRulePath(JPATH_COMPONENT.'/models/rules');
 
-    $form = JForm::getInstance(_JOOM_OPTION.'.editimages', 'editimages');
+    $form = JForm::getInstance(_JOOM_OPTION.'.editimages', 'editimages', array('control' => 'jform'));
+
     if(empty($form))
     {
       return false;

--- a/administrator/components/com_joomgallery/models/favourites.php
+++ b/administrator/components/com_joomgallery/models/favourites.php
@@ -34,7 +34,7 @@ class JoomGalleryModelFavourites extends JoomGalleryModel
           ->delete(_JOOM_TABLE_USERS);
     $this->_db->setQuery($query);
 
-    if(!$this->_db->query())
+    if(!$this->_db->execute())
     {
       $this->setError($this->_db->getErrorMsg());
 
@@ -69,7 +69,7 @@ class JoomGalleryModelFavourites extends JoomGalleryModel
           ->where('NOT EXISTS ('.$subquery.')');
     $this->_db->setQuery($query);
 
-    if(!$this->_db->query())
+    if(!$this->_db->execute())
     {
       $this->setError($this->_db->getErrorMsg());
 

--- a/administrator/components/com_joomgallery/models/fields/cbaccesslevel.php
+++ b/administrator/components/com_joomgallery/models/fields/cbaccesslevel.php
@@ -45,7 +45,14 @@ class JFormFieldCbAccessLevel extends JFormFieldAccessLevel
 
     $cbname     = $this->element['cbname'] ? $this->element['cbname'] : 'change[]';
     $cbvalue    = $this->element['cbvalue'] ? $this->element['cbvalue'] : $this->name;
-    $cbid       = str_replace(array('[', ']'), array('', ''), $cbname.$cbvalue);
+    $cbid       = str_replace(array('[', ']'), array('', ''), $cbname . '_' . $cbvalue);
+
+    if($this->formControl && strlen($cbname) > 2 && substr($cbname, -2) === '[]')
+    {
+      $cbname = $this->formControl . '[' . substr($cbname, 0, -2) . '][]';
+      $cbid   = $this->formControl . '_' . $cbid;
+    }
+
     $cbhtml     = '<input id="'.$cbid.'" type="checkbox" name="'.$cbname.'" value="'.$cbvalue.'" />';
     $label      = parent::getLabel();
     $insertpos  = strpos($label, '>');

--- a/administrator/components/com_joomgallery/models/fields/cbcategory.php
+++ b/administrator/components/com_joomgallery/models/fields/cbcategory.php
@@ -46,7 +46,13 @@ class JFormFieldCbcategory extends JFormFieldJoomCategory
     $cbname     = $this->element['cbname'] ? $this->element['cbname'] : 'change[]';
     $cbvalue    = $this->element['cbvalue'] ? $this->element['cbvalue'] : $this->name;
     $validate   = $this->element['validate'] ? (string) $this->element['validate'] : '';
-    $cbid       = str_replace(array('[', ']'), array('', ''), $cbname.$cbvalue);
+    $cbid       = str_replace(array('[', ']'), array('', ''), $cbname . '_' . $cbvalue);
+
+    if($this->formControl && strlen($cbname) > 2 && substr($cbname, -2) === '[]')
+    {
+      $cbname = $this->formControl . '[' . substr($cbname, 0, -2) . '][]';
+      $cbid   = $this->formControl . '_' . $cbid;
+    }
 
     $cbonclick = '';
     if(!empty($validate))

--- a/administrator/components/com_joomgallery/models/fields/cbeditor.php
+++ b/administrator/components/com_joomgallery/models/fields/cbeditor.php
@@ -45,8 +45,14 @@ class JFormFieldCbeditor extends JFormFieldEditor
 
     $cbname     = $this->element['cbname'] ? $this->element['cbname'] : 'change[]';
     $cbvalue    = $this->element['cbvalue'] ? $this->element['cbvalue'] : $this->name;
+    $cbid       = str_replace(array('[', ']'), array('', ''), $cbname . '_' . $cbvalue);
 
-    $cbid       = str_replace(array('[', ']'), array('', ''), $cbname.$cbvalue);
+    if($this->formControl && strlen($cbname) > 2 && substr($cbname, -2) === '[]')
+    {
+      $cbname = $this->formControl . '[' . substr($cbname, 0, -2) . '][]';
+      $cbid   = $this->formControl . '_' . $cbid;
+    }
+
     $cbhtml     = '<input id="'.$cbid.'" type="checkbox" name="'.$cbname.'" value="'.$cbvalue.'" />';
     $label      = parent::getLabel();
     $insertpos  = strpos($label, '>');

--- a/administrator/components/com_joomgallery/models/fields/cbjoomuser.php
+++ b/administrator/components/com_joomgallery/models/fields/cbjoomuser.php
@@ -45,8 +45,14 @@ class JFormFieldCbjoomuser extends JFormFieldJoomuser
 
     $cbname     = $this->element['cbname'] ? $this->element['cbname'] : 'change[]';
     $cbvalue    = $this->element['cbvalue'] ? $this->element['cbvalue'] : $this->name;
+    $cbid       = str_replace(array('[', ']'), array('', ''), $cbname . '_' . $cbvalue);
 
-    $cbid       = str_replace(array('[', ']'), array('', ''), $cbname.$cbvalue);
+    if($this->formControl && strlen($cbname) > 2 && substr($cbname, -2) === '[]')
+    {
+      $cbname = $this->formControl . '[' . substr($cbname, 0, -2) . '][]';
+      $cbid   = $this->formControl . '_' . $cbid;
+    }
+
     $cbhtml     = '<input id="'.$cbid.'" type="checkbox" name="'.$cbname.'" value="'.$cbvalue.'" />';
     $label      = $cbhtml . parent::getLabel();
 

--- a/administrator/components/com_joomgallery/models/fields/cblist.php
+++ b/administrator/components/com_joomgallery/models/fields/cblist.php
@@ -45,8 +45,14 @@ class JFormFieldCblist extends JFormFieldList
 
     $cbname     = $this->element['cbname'] ? $this->element['cbname'] : 'change[]';
     $cbvalue    = $this->element['cbvalue'] ? $this->element['cbvalue'] : $this->name;
+    $cbid       = str_replace(array('[', ']'), array('', ''), $cbname . '_' . $cbvalue);
 
-    $cbid       = str_replace(array('[', ']'), array('', ''), $cbname.$cbvalue);
+    if($this->formControl && strlen($cbname) > 2 && substr($cbname, -2) === '[]')
+    {
+      $cbname = $this->formControl . '[' . substr($cbname, 0, -2) . '][]';
+      $cbid   = $this->formControl . '_' . $cbid;
+    }
+
     $cbhtml     = '<input id="'.$cbid.'" type="checkbox" name="'.$cbname.'" value="'.$cbvalue.'" />';
     $label      = parent::getLabel();
     $insertpos  = strpos($label, '>');

--- a/administrator/components/com_joomgallery/models/fields/cbtext.php
+++ b/administrator/components/com_joomgallery/models/fields/cbtext.php
@@ -46,7 +46,13 @@ class JFormFieldCbtext extends JFormFieldText
     $cbname     = $this->element['cbname'] ? $this->element['cbname'] : 'change[]';
     $cbvalue    = $this->element['cbvalue'] ? $this->element['cbvalue'] : $this->name;
     $cbrequired = $this->element['cbrequired'] ? (string) $this->element['cbrequired'] : 'false';
-    $cbid       = str_replace(array('[', ']'), array('', ''), $cbname.$cbvalue);
+    $cbid       = str_replace(array('[', ']'), array('', ''), $cbname . '_' . $cbvalue);
+
+    if($this->formControl && strlen($cbname) > 2 && substr($cbname, -2) === '[]')
+    {
+      $cbname = $this->formControl . '[' . substr($cbname, 0, -2) . '][]';
+      $cbid   = $this->formControl . '_' . $cbid;
+    }
 
     $cbonclick = '';
     if($cbrequired == 'true' || $cbrequired == 'required' || $cbrequired == '1')

--- a/administrator/components/com_joomgallery/models/fields/cbtextarea.php
+++ b/administrator/components/com_joomgallery/models/fields/cbtextarea.php
@@ -46,7 +46,13 @@ class JFormFieldCbtextarea extends JFormFieldTextarea
     $cbname     = $this->element['cbname'] ? $this->element['cbname'] : 'change[]';
     $cbvalue    = $this->element['cbvalue'] ? $this->element['cbvalue'] : $this->name;
     $cbrequired = $this->element['cbrequired'] ? (string) $this->element['cbrequired'] : 'false';
-    $cbid       = str_replace(array('[', ']'), array('', ''), $cbname.$cbvalue);
+    $cbid       = str_replace(array('[', ']'), array('', ''), $cbname . '_' . $cbvalue);
+
+    if($this->formControl && strlen($cbname) > 2 && substr($cbname, -2) === '[]')
+    {
+      $cbname = $this->formControl . '[' . substr($cbname, 0, -2) . '][]';
+      $cbid   = $this->formControl . '_' . $cbid;
+    }
 
     $cbonclick = '';
     if($cbrequired == 'true' || $cbrequired == 'required' || $cbrequired == '1')

--- a/administrator/components/com_joomgallery/models/fields/thumbnail.php
+++ b/administrator/components/com_joomgallery/models/fields/thumbnail.php
@@ -51,7 +51,7 @@ class JFormFieldThumbnail extends JFormField
     if($app->isAdmin())
     {
       // Get category id from request
-      $cids   = JRequest::getVar('cid', array(), '', 'array');
+      $cids = $app->input->get('cid', array(), 'array');
 
       if(isset($cids[0]))
       {
@@ -64,7 +64,7 @@ class JFormFieldThumbnail extends JFormField
     else
     {
       // Get category id from request
-      $catid = JRequest::getInt('catid', 0);
+      $catid = $app->input->getInt('catid', 0);
 
       // Prepare the path for the thumbnail preview
       $path = JRoute::_('index.php?option=' . _JOOM_OPTION . '&view=image&format=raw&type=thumb', false) . '&id=';

--- a/administrator/components/com_joomgallery/models/forms/category.xml
+++ b/administrator/components/com_joomgallery/models/forms/category.xml
@@ -18,7 +18,7 @@
       type="text"
       class="inputbox"
       name="name"
-      id="jform_title"
+      id="title"
       label="COM_JOOMGALLERY_COMMON_TITLE"
       maxLength="255"
       required="true"
@@ -119,7 +119,7 @@
       label="COM_JOOMGALLERY_COMMON_THUMBNAIL_PREVIEW"
     />
     <field
-      id="jform_rules"
+      id="rules"
       name="rules"
       type="rules"
       label="JFIELD_RULES_LABEL"

--- a/administrator/components/com_joomgallery/models/forms/image.xml
+++ b/administrator/components/com_joomgallery/models/forms/image.xml
@@ -28,7 +28,7 @@
       name="imgtitle"
       type="text"
       class="inputbox"
-      id="jform_title"
+      id="title"
       label="COM_JOOMGALLERY_COMMON_TITLE"
       maxLength="255"
       required="true"
@@ -168,7 +168,7 @@
       label="COM_JOOMGALLERY_IMGMAN_IMAGE_PREVIEW"
     />
     <field
-      id="jform_rules"
+      id="rules"
       name="rules"
       type="rules"
       label="JFIELD_RULES_LABEL"

--- a/administrator/components/com_joomgallery/models/image.php
+++ b/administrator/components/com_joomgallery/models/image.php
@@ -13,8 +13,6 @@
 
 defined('_JEXEC') or die('Direct Access to this location is not allowed.');
 
-jimport('joomla.form.form');
-
 /**
  * Image model
  *
@@ -47,7 +45,7 @@ class JoomGalleryModelImage extends JoomGalleryModel
   {
     parent::__construct();
 
-    $array = JRequest::getVar('cid',  0, '', 'array');
+    $array = $this->_mainframe->input->get('cid', array(0), 'array');
     $this->setId((int)$array[0]);
   }
 
@@ -78,30 +76,49 @@ class JoomGalleryModelImage extends JoomGalleryModel
 
     if(!$this->_id)
     {
-      $row->imgtitle      = $this->_mainframe->getUserStateFromRequest('joom.image.imgtitle',       'imgtitle');
-      $row->imgtext       = $this->_mainframe->getUserStateFromRequest('joom.image.imgtext',        'imgtext');
-      $row->imgauthor     = $this->_mainframe->getUserStateFromRequest('joom.image.imgauthor',      'imgauthor');
-      $row->owner         = $this->_mainframe->getUserStateFromRequest('joom.image.owner',          'owner');
-      $row->metadesc      = $this->_mainframe->getUserStateFromRequest('joom.image.metadesc',       'metadesc');
-      $row->metakey       = $this->_mainframe->getUserStateFromRequest('joom.image.metakey',        'metakey');
-      $row->published     = $this->_mainframe->getUserStateFromRequest('joom.image.published',      'published', 1, 'int');
-      $row->imgfilename   = $this->_mainframe->getUserStateFromRequest('joom.image.imgfilename',    'imgfilename');
-      $row->imgthumbname  = $this->_mainframe->getUserStateFromRequest('joom.image.imgthumbname',   'imgthumbname');
-      $row->catid         = $this->_mainframe->getUserStateFromRequest('joom.image.catid',          'catid', 0, 'int');
-      $row->access        = $this->_mainframe->getUserStateFromRequest('joom.image.access',         'access', 1, 'int');
-      // Source category for original and detail picture
-      $row->detail_catid  = $this->_mainframe->getUserStateFromRequest('joom.image.detail_catid',   'detail_catid', 0, 'int');
-      if(!$row->detail_catid)
+
+      $formData = $this->_mainframe->getUserStateFromRequest('joom.image.jform', 'jform', NULL, 'array');
+
+      if($formData != NULL)
       {
-        $row->imgfilename = '';
+        $row->imgtitle      = $formData['imgtitle'];
+        $row->imgtext       = $formData['imgtext'];
+        $row->imgauthor     = $formData['imgauthor'];
+        $row->owner         = $formData['owner'];
+        $row->metadesc      = $formData['metadesc'];
+        $row->metakey       = $formData['metakey'];
+        $row->published     = $formData['published'];
+        $row->imgfilename   = $formData['imgfilename'];
+        $row->imgthumbname  = $formData['imgthumbname'];
+        $row->catid         = $formData['catid'];
+        $row->access        = $formData['access'];
+        // Source category for original and detail picture
+        $row->detail_catid  = $formData['detail_catid'];
+        if(empty($row->detail_catid))
+        {
+          $row->detail_catid = 0;
+          $row->imgfilename  = '';
+        }
+        // Source category for thumbnail
+        $row->thumb_catid   = $formData['thumb_catid'];
+        if(empty($row->thumb_catid))
+        {
+          $row->thumb_catid  = 0;
+          $row->imgthumbname = '';
+        }
+        $row->copy_original = $formData['copy_original'];
       }
-      // Source category for thumbnail
-      $row->thumb_catid   = $this->_mainframe->getUserStateFromRequest('joom.image.thumb_catid',    'thumb_catid', 0, 'int');
-      if(!$row->thumb_catid)
+      else
       {
-        $row->imgthumbname = '';
+        $row->published     = 1;
+        $row->catid         = 0;
+        $row->access        = 1;
+        $row->detail_catid  = 0;
+        $row->imgfilename   = '';
+        $row->thumb_catid   = 0;
+        $row->imgthumbname  = '';
+        $row->copy_original = 0;
       }
-      $row->copy_original = $this->_mainframe->getUserStateFromRequest('joom.image.copy_original',  'copy_original', 0, 'int');
     }
 
     $this->_mainframe->triggerEvent('onContentPrepareData', array(_JOOM_OPTION.'.image', $row));
@@ -153,7 +170,7 @@ class JoomGalleryModelImage extends JoomGalleryModel
     JForm::addFieldPath(JPATH_COMPONENT.'/models/fields');
     JForm::addRulePath(JPATH_COMPONENT.'/models/rules');
 
-    $form = JForm::getInstance(_JOOM_OPTION.'.image', 'image');
+    $form = JForm::getInstance(_JOOM_OPTION.'.image', 'image', array('control' => 'jform'));
     if(empty($form))
     {
       return false;
@@ -228,7 +245,8 @@ class JoomGalleryModelImage extends JoomGalleryModel
     $validate = true;
     if(is_null($data))
     {
-      $data = JRequest::get('post', 2);
+      $data        = $this->_mainframe->input->post->get('jform', array(), 'array');
+      $data['cid'] = $this->_mainframe->input->post->getInt('cid');
     }
     else
     {
@@ -237,7 +255,7 @@ class JoomGalleryModelImage extends JoomGalleryModel
     }
     if(is_null($params))
     {
-      $params = JRequest::getVar('params', array(), 'post', 'array');
+      $params = $this->_mainframe->input->post->get('params', array(), 'array');
     }
 
     // Check for validation errors
@@ -384,7 +402,7 @@ class JoomGalleryModelImage extends JoomGalleryModel
     // Get new image files
     if(is_null($files))
     {
-      $files = JRequest::getVar('files', '', 'files');
+      $files = $this->_mainframe->input->files->get('jform', NULL, 'raw');
     }
 
     // Clear votes if 'clearvotes' is checked
@@ -399,7 +417,7 @@ class JoomGalleryModelImage extends JoomGalleryModel
             ->where('picid = '.$row->id);
 
       $this->_db->setQuery($query);
-      if(!$this->_db->query())
+      if(!$this->_db->execute())
       {
         $this->setError($row->getError());
 
@@ -423,12 +441,12 @@ class JoomGalleryModelImage extends JoomGalleryModel
     $types = array('thumb', 'img', 'orig');
     foreach($types as $type)
     {
-      if(isset($files['tmp_name']) && isset($files['tmp_name'][$type]) && $files['tmp_name'][$type])
+      if(isset($files['files']) && isset($files['files'][$type]) && isset($files['files'][$type]['tmp_name']) && $files['files'][$type]['tmp_name'])
       {
         jimport('joomla.filesystem.file');
 
         // Possibly the file name has to be changed because of another image format
-        $temp_filename = $files['name'][$type];
+        $temp_filename = $files['files'][$type]['name'];
         $columnname = 'imgfilename';
         if($type == 'thumb')
         {
@@ -445,9 +463,9 @@ class JoomGalleryModelImage extends JoomGalleryModel
         // Upload the file
         $file = $this->_ambit->getImg($type.'_path', $row);
         //JFile::delete($file);
-        if(!JFile::upload($files['tmp_name'][$type], $file))
+        if(!JFile::upload($files['files'][$type]['tmp_name'], $file))
         {
-          JError::raiseWarning(500, JText::sprintf('COM_JOOMGALLERY_UPLOAD_ERROR_UPLOADING', $this->_ambit->getImg($type.'_path', $row)));
+          $this->_mainframe->enqueueMessage(JText::sprintf('COM_JOOMGALLERY_UPLOAD_ERROR_UPLOADING', $this->_ambit->getImg($type.'_path', $row)), 'error');
 
           // Revert database entry
           $row->$columnname = $filename;
@@ -464,8 +482,10 @@ class JoomGalleryModelImage extends JoomGalleryModel
                                             $this->_config->get('jg_thumbwidth'),
                                             $this->_config->get('jg_thumbheight'),
                                             $this->_config->get('jg_thumbcreation'),
-                                            $this->_config->get('jg_thumbquality')
-                                            );
+                                            $this->_config->get('jg_thumbquality'),
+                                            false,
+                                            $this->_config->get('jg_cropposition')
+                                           );
             break;
           case 'img':
             $return = JoomFile::resizeImage($debugoutput,
@@ -476,7 +496,8 @@ class JoomGalleryModelImage extends JoomGalleryModel
                                             false,
                                             $this->_config->get('jg_thumbcreation'),
                                             $this->_config->get('jg_picturequality'),
-                                            true
+                                            true,
+                                            0
                                             );
             break;
           default:
@@ -562,7 +583,7 @@ class JoomGalleryModelImage extends JoomGalleryModel
    *
    * @param   string  $file   The file name to look for
    * @param   int     $catid  Optional category ID for setting an additional limit
-   * @param   thumb   $thumb  True if the given file name is the name of a thumbnail, false otherwise
+   * @param   boolean $thumb  True if the given file name is the name of a thumbnail, false otherwise
    * @return  int     The ID of the image
    * @since   2.0
    */
@@ -795,7 +816,7 @@ class JoomGalleryModelImage extends JoomGalleryModel
     $thumb_dest     = $this->_ambit->get('thumb_path').$catpath_new.$item->imgthumbname;
     if(JFile::exists($thumb_dest))
     {
-      JError::raiseNotice(0, JText::_('COM_JOOMGALLERY_COMMON_DEST_THUMB_ALREADY_EXISTS'));
+      $this->_mainframe->enqueueMessage(JText::_('COM_JOOMGALLERY_COMMON_DEST_THUMB_ALREADY_EXISTS'), 'notice');
 
       if($thumb_count && JFile::exists($thumb_source))
       {
@@ -806,7 +827,7 @@ class JoomGalleryModelImage extends JoomGalleryModel
     {
       if(!JFile::exists($thumb_source))
       {
-        JError::raiseWarning(500, JText::sprintf('COM_JOOMGALLERY_COMMON_SOURCE_THUMB_NOT_EXISTS', $thumb_source));
+        $this->_mainframe->enqueueMessage(JText::sprintf('COM_JOOMGALLERY_COMMON_SOURCE_THUMB_NOT_EXISTS', $thumb_source), 'error');
 
         return false;
       }
@@ -827,7 +848,7 @@ class JoomGalleryModelImage extends JoomGalleryModel
         // If not succesful raise an error message and abort
         if(!$result)
         {
-          JError::raiseWarning(100, JText::sprintf('COM_JOOMGALLERY_COULD_NOT_MOVE_THUMB', JPath::clean($thumb_dest)));
+          $this->_mainframe->enqueueMessage(JText::sprintf('COM_JOOMGALLERY_COULD_NOT_MOVE_THUMB', JPath::clean($thumb_dest)), 'error');
 
           return false;
         }
@@ -854,7 +875,7 @@ class JoomGalleryModelImage extends JoomGalleryModel
     $img_dest     = $this->_ambit->get('img_path').$catpath_new.$item->imgfilename;
     if(JFile::exists($img_dest))
     {
-      JError::raiseNotice(0, JText::_('COM_JOOMGALLERY_COMMON_DEST_IMG_ALREADY_EXISTS'));
+      $this->_mainframe->enqueueMessage(JText::_('COM_JOOMGALLERY_COMMON_DEST_IMG_ALREADY_EXISTS'), 'notice');
 
       if($img_count && JFile::exists($img_source))
       {
@@ -865,7 +886,7 @@ class JoomGalleryModelImage extends JoomGalleryModel
     {
       if(!JFile::exists($img_source))
       {
-        JError::raiseWarning(500, JText::sprintf('COM_JOOMGALLERY_COMMON_SOURCE_IMG_NOT_EXISTS', $img_source));
+        $this->_mainframe->enqueueMessage(JText::sprintf('COM_JOOMGALLERY_COMMON_SOURCE_IMG_NOT_EXISTS', $img_source), 'error');
 
         return false;
       }
@@ -893,7 +914,7 @@ class JoomGalleryModelImage extends JoomGalleryModel
             }
           }
 
-          JError::raiseWarning(100, JText::sprintf('COM_JOOMGALLERY_COULD_NOT_MOVE_IMG', JPath::clean($img_dest)));
+          $this->_mainframe->enqueueMessage(JText::sprintf('COM_JOOMGALLERY_COULD_NOT_MOVE_IMG', JPath::clean($img_dest)), 'error');
 
           return false;
         }
@@ -908,7 +929,7 @@ class JoomGalleryModelImage extends JoomGalleryModel
     $orig_dest    = $this->_ambit->get('orig_path').$catpath_new.$item->imgfilename;
     if(JFile::exists($orig_dest))
     {
-      JError::raiseNotice(0, JText::_('COM_JOOMGALLERY_COMMON_DEST_ORIG_ALREADY_EXISTS'));
+      $this->_mainframe->enqueueMessage(JText::_('COM_JOOMGALLERY_COMMON_DEST_ORIG_ALREADY_EXISTS'), 'notice');
 
       if($img_count && JFile::exists($orig_source))
       {
@@ -952,7 +973,7 @@ class JoomGalleryModelImage extends JoomGalleryModel
             }
           }
 
-          JError::raiseWarning(100, JText::sprintf('COM_JOOMGALLERY_COULD_NOT_MOVE_ORIGINAL', JPath::clean($orig_dest)));
+          $this->_mainframe->enqueueMessage(JText::sprintf('COM_JOOMGALLERY_COULD_NOT_MOVE_ORIGINAL', JPath::clean($orig_dest)), 'error');
 
           return false;
         }
@@ -967,7 +988,7 @@ class JoomGalleryModelImage extends JoomGalleryModel
     // Make sure the record is valid
     if(!$item->check())
     {
-      JError::raiseWarning($item->getError());
+      $this->_mainframe->enqueueMessage($item->getError(), 'error');
 
       return false;
     }
@@ -975,7 +996,7 @@ class JoomGalleryModelImage extends JoomGalleryModel
     // Store the entry to the database
     if(!$item->store())
     {
-      JError::raiseWarning($item->getError());
+      $this->_mainframe->enqueueMessage($item->getError(), 'error');
 
       return false;
     }

--- a/administrator/components/com_joomgallery/models/image.php
+++ b/administrator/components/com_joomgallery/models/image.php
@@ -210,23 +210,8 @@ class JoomGalleryModelImage extends JoomGalleryModel
     // Import the appropriate plugin group
     JPluginHelper::importPlugin($group);
 
-    // Get the dispatcher
-    $dispatcher = JDispatcher::getInstance();
-
     // Trigger the form preparation event
-    $results = $dispatcher->trigger('onContentPrepareForm', array($form, $data));
-
-    // Check for errors encountered while preparing the form
-    if(count($results) && in_array(false, $results, true))
-    {
-      // Get the last error
-      $error = $dispatcher->getError();
-
-      if(!($error instanceof Exception))
-      {
-        throw new Exception($error);
-      }
-    }
+    $this->_mainframe->triggerEvent('onContentPrepareForm', array($form, $data));
   }
 
   /**

--- a/administrator/components/com_joomgallery/models/images.php
+++ b/administrator/components/com_joomgallery/models/images.php
@@ -13,6 +13,8 @@
 
 defined('_JEXEC') or die('Direct Access to this location is not allowed.');
 
+use Joomla\Utilities\ArrayHelper;
+
 /**
  * Images model
  *
@@ -194,7 +196,7 @@ class JoomGalleryModelImages extends JoomGalleryModel
   protected function loadForm($name, $source = null, $options = array(), $clear = false, $xpath = false)
   {
     // Handle the optional arguments.
-    $options['control'] = JArrayHelper::getValue($options, 'control', false);
+    $options['control'] = ArrayHelper::getValue($options, 'control', false);
 
     // Get the form.
     JForm::addFormPath(JPATH_COMPONENT . '/models/forms');
@@ -490,7 +492,7 @@ class JoomGalleryModelImages extends JoomGalleryModel
             ->where('cmtpic = '.$cid);
 
       $this->_db->setQuery($query);
-      if(!$this->_db->query())
+      if(!$this->_db->execute())
       {
         JLog::add(JText::sprintf('COM_JOOMGALLERY_MAIMAN_MSG_NOT_DELETE_COMMENTS', $cid), JLog::WARNING, 'jerror');
       }
@@ -502,7 +504,7 @@ class JoomGalleryModelImages extends JoomGalleryModel
             ->where('npicid = '.$cid);
 
       $this->_db->setQuery($query);
-      if(!$this->_db->query())
+      if(!$this->_db->execute())
       {
         JLog::add(JText::sprintf('COM_JOOMGALLERY_MAIMAN_MSG_NOT_DELETE_NAMETAGS', $cid), JLog::WARNING, 'jerror');
       }
@@ -514,7 +516,7 @@ class JoomGalleryModelImages extends JoomGalleryModel
             ->where('picid = '.$cid);
 
       $this->_db->setQuery($query);
-      if(!$this->_db->query())
+      if(!$this->_db->execute())
       {
         JLog::add(JText::sprintf('COM_JOOMGALLERY_MAIMAN_MSG_NOT_DELETE_VOTES', $cid), JLog::WARNING, 'jerror');
       }
@@ -553,7 +555,7 @@ class JoomGalleryModelImages extends JoomGalleryModel
    */
   public function publish($cid, $publish = 1, $task = 'publish')
   {
-    JArrayHelper::toInteger($cid);
+    ArrayHelper::toInteger($cid);
     $publish = intval($publish);
     $count = count($cid);
 
@@ -663,7 +665,7 @@ class JoomGalleryModelImages extends JoomGalleryModel
 
     require_once JPATH_COMPONENT.'/helpers/refresher.php';
 
-    $refresher = new JoomRefresher(array('controller' => 'images', 'task' => 'recreate', 'remaining' => count($cids), 'start' => JRequest::getBool('cid')));
+    $refresher = new JoomRefresher(array('controller' => 'images', 'task' => 'recreate', 'remaining' => count($cids), 'start' => $this->_mainframe->input->getBool('cid')));
 
     $debugoutput = '';
 
@@ -691,7 +693,7 @@ class JoomGalleryModelImages extends JoomGalleryModel
         }
         else
         {
-          JError::raiseWarning(100, JText::sprintf('COM_JOOMGALLERY_IMGMAN_MSG_IMAGE_NOT_EXISTENT', $img));
+          $this->_mainframe->enqueueMessage(JText::sprintf('COM_JOOMGALLERY_IMGMAN_MSG_IMAGE_NOT_EXISTENT', $img), 'error');
           $this->_mainframe->setUserState('joom.recreate.cids', array());
           $this->_mainframe->setUserState('joom.recreate.imgcount', null);
           $this->_mainframe->setUserState('joom.recreate.thumbcount', null);
@@ -721,7 +723,7 @@ class JoomGalleryModelImages extends JoomGalleryModel
                                         );
         if(!$return)
         {
-          JError::raiseWarning(100, JText::sprintf('COM_JOOMGALLERY_IMGMAN_MSG_COULD_NOT_CREATE_THUMB', $thumb));
+          $this->_mainframe->enqueueMessage(JText::sprintf('COM_JOOMGALLERY_IMGMAN_MSG_COULD_NOT_CREATE_THUMB', $thumb), 'error');
           $this->_mainframe->setUserState('joom.recreate.cids', array());
           $this->_mainframe->setUserState('joom.recreate.thumbcount', null);
           $this->_mainframe->setUserState('joom.recreate.imgcount', null);
@@ -755,11 +757,12 @@ class JoomGalleryModelImages extends JoomGalleryModel
                                         );
         if(!$return)
         {
-          JError::raiseWarning(100, JText::sprintf('COM_JOOMGALLERY_IMGMAN_MSG_COULD_NOT_CREATE_IMG', $img));
+          $this->_mainframe->enqueueMessage(JText::sprintf('COM_JOOMGALLERY_IMGMAN_MSG_COULD_NOT_CREATE_IMG', $img), 'error');
           $this->_mainframe->setUserState('joom.recreate.cids', array());
           $this->_mainframe->setUserState('joom.recreate.thumbcount', null);
           $this->_mainframe->setUserState('joom.recreate.imgcount', null);
           $this->_mainframe->setUserState('joom.recreate.recreated', null);
+
           return false;
         }
 
@@ -956,7 +959,7 @@ class JoomGalleryModelImages extends JoomGalleryModel
 
     $old_state = $app->getUserState($key);
     $cur_state = (!is_null($old_state)) ? $old_state : $default;
-    $new_state = JRequest::getVar($request, null, 'default', $type);
+    $new_state = $app->input->get($request, null, $type);
 
     // Special case for owner filter since Joomla! 3.5 when using modal user selection
     if(    !is_null($new_state) && isset($new_state['owner'])
@@ -968,7 +971,7 @@ class JoomGalleryModelImages extends JoomGalleryModel
 
     if($cur_state != $new_state && !is_null($new_state) && !is_null($old_state) && $resetPage)
     {
-      JRequest::setVar('limitstart', 0);
+      $app->input->set('limitstart', 0);
     }
 
     // Save the new value only if it was set in this request.

--- a/administrator/components/com_joomgallery/models/maintenance.php
+++ b/administrator/components/com_joomgallery/models/maintenance.php
@@ -13,6 +13,8 @@
 
 defined('_JEXEC') or die('Direct Access to this location is not allowed.');
 
+use Joomla\Utilities\ArrayHelper;
+
 /**
  * Maintenance model
  *
@@ -255,7 +257,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
   {
     $total = 0;
 
-    switch(JRequest::getCmd('tab'))
+    switch($this->_mainframe->input->getCmd('tab'))
     {
       case 'categories':
         // Let's load the categories if they don't already exist
@@ -333,7 +335,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
    */
   protected function populateState($default_ordering = 'a.id', $default_direction = 'ASC')
   {
-    switch(JRequest::getCmd('tab'))
+    switch($this->_mainframe->input->getCmd('tab'))
     {
       case 'categories':
         $search     = $this->getUserStateFromRequest('joom.maintenance.categories.filter.search', 'filter_search');
@@ -465,9 +467,9 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
   {
     jimport('joomla.filesystem.file');
 
-    $cids = JRequest::getVar('cid', array(), 'post', 'array');
+    $cids = $this->_mainframe->input->post->get('cid', array(), 'array');
 
-    JArrayHelper::toInteger($cids);
+    ArrayHelper::toInteger($cids);
 
     if($refids)
     {
@@ -574,7 +576,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
             ->delete($this->_db->qn(_JOOM_TABLE_COMMENTS))
             ->where('cmtpic = '.$cid);
       $this->_db->setQuery($query);
-      if(!$this->_db->query())
+      if(!$this->_db->execute())
       {
         $this->_mainframe->enqueueMessage(JText::sprintf('COM_JOOMGALLERY_MAIMAN_MSG_NOT_DELETE_COMMENTS', $cid), 'error');
       }
@@ -584,7 +586,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
             ->delete($this->_db->qn(_JOOM_TABLE_NAMESHIELDS))
             ->where('npicid = '.$cid);
       $this->_db->setQuery($query);
-      if(!$this->_db->query())
+      if(!$this->_db->execute())
       {
         $this->_mainframe->enqueueMessage(JText::sprintf('COM_JOOMGALLERY_MAIMAN_MSG_NOT_DELETE_NAMETAGS', $cid), 'error');
       }
@@ -612,7 +614,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
             ->where('refid = '.$cid)
             ->where('type  = 0');
         $this->_db->setQuery($query);
-        if(!$this->_db->query())
+        if(!$this->_db->execute())
         {
           $this->_mainframe->enqueueMessage($this->_db->getErrorMsg(), 'error');
         }
@@ -636,9 +638,9 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
   {
     jimport('joomla.filesystem.file');
 
-    $cids = JRequest::getVar('cid', array(), 'post', 'array');
+    $cids = $this->_mainframe->input->post->get('cid', array(), 'array');
 
-    JArrayHelper::toInteger($cids);
+    ArrayHelper::toInteger($cids);
 
     if(!$recursion_level)
     {
@@ -759,7 +761,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
         $this->_mainframe->setUserState('joom.maintenance.delete.categories', $categories_to_delete);
 
         // Next level
-        JRequest::setVar('cid', $categories);
+        $this->_mainframe->input->post->set('cid', $categories);
         $this->deletecategory($recursion_level + 1, false);
       }
 
@@ -799,7 +801,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
               ->where('refid = '.$cid)
               ->where('type != 0');
         $this->_db->setQuery($query);
-        if(!$this->_db->query())
+        if(!$this->_db->execute())
         {
           $this->_mainframe->enqueueMessage($this->_db->getErrorMsg(), 'error');
         }
@@ -874,7 +876,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
     $img_count  = $this->_mainframe->getUserState('joom.setalias.imgcount');
     $cat_count  = $this->_mainframe->getUserState('joom.setalias.catcount');
 
-    $start      = (JRequest::getBool('images') || JRequest::getBool('categories'));
+    $start      = ($this->_mainframe->input->getBool('images') || $this->_mainframe->input->getBool('categories'));
 
     // Before first loop check for selected images and categories
     if(isset($images[0]) && strpos(',', $images[0]) !== false)
@@ -1008,8 +1010,8 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
    */
   public function setUser()
   {
-    $user = JRequest::getInt('newuser', 0);
-    $cids = JRequest::getVar('cid', array(), 'post', 'array');
+    $user = $this->_mainframe->input->getInt('newuser', 0);
+    $cids = $this->_mainframe->input->post->get('cid', array(), 'array');
 
     if(!count($cids))
     {
@@ -1018,7 +1020,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
       return false;
     }
 
-    JArrayHelper::toInteger($cids);
+    ArrayHelper::toInteger($cids);
     $cid_string = implode(',', $cids);
 
     // Get selected image IDs
@@ -1041,7 +1043,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
           ->set('owner = '.$user)
           ->where('id IN ('.implode(',', $ids).')');
     $this->_db->setQuery($query);
-    if(!$this->_db->query())
+    if(!$this->_db->execute())
     {
       $this->setError($this->_db->getErrorMsg());
 
@@ -1055,7 +1057,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
           ->where('id IN ('.$cid_string.')')
           ->where('type = 0');
     $this->_db->setQuery($query);
-    if(!$this->_db->query())
+    if(!$this->_db->execute())
     {
       $this->setError($this->_db->getErrorMsg());
 
@@ -1073,8 +1075,8 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
    */
   public function setCategoryUser()
   {
-    $user = JRequest::getInt('newuser', 0);
-    $cids = JRequest::getVar('cid', array(), 'post', 'array');
+    $user = $this->_mainframe->input->getInt('newuser', 0);
+    $cids =$this->_mainframe->input->post->get('cid', array(), 'array');
 
     if(!count($cids))
     {
@@ -1083,7 +1085,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
       return false;
     }
 
-    JArrayHelper::toInteger($cids);
+    ArrayHelper::toInteger($cids);
     $cid_string = implode(',', $cids);
 
     // Get selected category IDs
@@ -1106,7 +1108,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
           ->set('owner = '.$user)
           ->where('cid IN ('.implode(',', $ids).')');
     $this->_db->setQuery($query);
-    if(!$this->_db->query())
+    if(!$this->_db->execute())
     {
       $this->setError($this->_db->getErrorMsg());
 
@@ -1120,7 +1122,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
           ->where('id IN ('.$cid_string.')')
           ->where('type != 0');
     $this->_db->setQuery($query);
-    if(!$this->_db->query())
+    if(!$this->_db->execute())
     {
       $this->setError($this->_db->getErrorMsg());
 
@@ -1140,7 +1142,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
   {
     jimport('joomla.filesystem.file');
 
-    $orphans = JRequest::getVar('cid', array(), 'post', 'array');
+    $orphans = $this->_mainframe->input->post->get('cid', array(), 'array');
 
     if(!count($orphans))
     {
@@ -1162,7 +1164,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
 
       if(!JFile::delete($row->fullpath))
       {
-        JError::raiseWarning(100, JText::sprintf('COM_JOOMGALLERY_MAIMAN_MSG_DELETE_FILE_VIA_FTP', $row->fullpath));
+        $this->_mainframe->enqueueMessage(JText::sprintf('COM_JOOMGALLERY_MAIMAN_MSG_DELETE_FILE_VIA_FTP', $row->fullpath), 'error');
       }
       else
       {
@@ -1174,7 +1176,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
                 ->where('refid = '.$row->refid)
                 ->where('type = 0');
           $this->_db->setQuery($query);
-          if(!$this->_db->query())
+          if(!$this->_db->execute())
           {
             $this->setError($this->_db->getErrorMsg());
 
@@ -1204,7 +1206,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
    */
   public function deleteOrphanedFolder()
   {
-    $folders = JRequest::getVar('cid', array(), 'post', 'array');
+    $folders = $this->_mainframe->input->post->get('cid', array(), 'array');
 
     if(!count($folders))
     {
@@ -1226,7 +1228,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
 
       if(!JFolder::delete($row->fullpath))
       {
-        JError::raiseWarning(100, JText::sprintf('COM_JOOMGALLERY_MAIMAN_OF_MSG_DELETE_FOLDER_VIA_FTP', $row->fullpath));
+        $this->_mainframe->enqueueMessage(JText::sprintf('COM_JOOMGALLERY_MAIMAN_OF_MSG_DELETE_FOLDER_VIA_FTP', $row->fullpath), 'error');
       }
       else
       {
@@ -1238,7 +1240,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
                 ->where('refid = '.$row->refid)
                 ->where('type != 0');
           $this->_db->setQuery($query);
-          if(!$this->_db->query())
+          if(!$this->_db->execute())
           {
             $this->setError($this->_db->getErrorMsg());
 
@@ -1269,7 +1271,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
    */
   public function addOrphans()
   {
-    $cids = JRequest::getVar('cid', array(), '', 'array');
+    $cids = $this->_mainframe->input->get('cid', array(), 'array');
 
     if(!count($cids))
     {
@@ -1286,7 +1288,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
     {
       if(!$image->load($id))
       {
-        JError::raiseNotice(500, JText::sprintf('COM_JOOMGALLERY_MAIMAN_MSG_IMAGE_WITH_ID_NOT_FOUND', $id));
+        $this->_mainframe->enqueueMessage(JText::sprintf('COM_JOOMGALLERY_MAIMAN_MSG_IMAGE_WITH_ID_NOT_FOUND', $id), 'notice');
         unset($cids[$key]);
         continue;
       }
@@ -1310,7 +1312,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
       return false;
     }
 
-    JRequest::setVar('cid', $orphans);
+    $this->_mainframe->input->set('cid', $orphans);
 
     return $this->addOrphan();
   }
@@ -1323,7 +1325,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
    */
   public function addOrphan()
   {
-    $cids = JRequest::getVar('cid', array(), '', 'array');
+    $cids = $this->_mainframe->input->get('cid', array(), 'array');
 
     if(!count($cids))
     {
@@ -1339,7 +1341,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
     {
       if(!$orphan->load($id))
       {
-        JError::raiseNotice(500, JText::sprintf('COM_JOOMGALLERY_MAIMAN_MSG_ORPHAN_WITH_ID_NOT_FOUND', $id));
+        $this->_mainframe->enqueueMessage(JText::sprintf('COM_JOOMGALLERY_MAIMAN_MSG_ORPHAN_WITH_ID_NOT_FOUND', $id), 'notice');
         continue;
       }
 
@@ -1358,7 +1360,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
       $this->_db->setQuery($query);
       if(!$image = $this->_db->loadObject())
       {
-        JError::raiseNotice(500, JText::sprintf('COM_JOOMGALLERY_MAIMAN_MSG_CORRUPT_IMAGE_WITH_ID_NOT_FOUND', $id, $orphan->refid));
+        $this->_mainframe->enqueueMessage(JText::sprintf('COM_JOOMGALLERY_MAIMAN_MSG_CORRUPT_IMAGE_WITH_ID_NOT_FOUND', $id, $orphan->refid), 'notice');
         continue;
       }
 
@@ -1380,7 +1382,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
           }
           else
           {
-            JError::raiseNotice(500, JText::sprintf('COM_JOOMGALLERY_MAIMAN_MSG_SUGGESTED_IMAGE_NOT_CORRUPT', $id, $orphan->refid));
+            $this->_mainframe->enqueueMessage(JText::sprintf('COM_JOOMGALLERY_MAIMAN_MSG_SUGGESTED_IMAGE_NOT_CORRUPT', $id, $orphan->refid), 'notice');
             continue;
           }
         }
@@ -1394,7 +1396,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
 
       if(!JFile::move($src, $dest))
       {
-        JError::raiseWarning(500, JText::sprintf('COM_JOOMGALLERY_MAIMAN_MSG_NOT_MOVE_FILE', $src, $dest));
+        $this->_mainframe->enqueueMessage(JText::sprintf('COM_JOOMGALLERY_MAIMAN_MSG_NOT_MOVE_FILE', $src, $dest), 'error');
         continue;
       }
 
@@ -1407,7 +1409,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
             ->where('type = 0');
 
       $this->_db->setQuery($query);
-      if(!$this->_db->query())
+      if(!$this->_db->execute())
       {
         $this->setError($this->_db->getErrorMsg());
 
@@ -1436,7 +1438,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
    */
   public function addOrphanedFolders()
   {
-    $cids = JRequest::getVar('cid', array(), '', 'array');
+    $cids = $this->_mainframe->input->get('cid', array(), 'array');
 
     if(!count($cids))
     {
@@ -1452,7 +1454,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
     {
       if(!$category->load($id))
       {
-        JError::raiseNotice(500, JText::sprintf('COM_JOOMGALLERY_MAIMAN_OF_MSG_CATEGORY_WITH_ID_NOT_FOUND', $id));
+        $this->_mainframe->enqueueMessage(JText::sprintf('COM_JOOMGALLERY_MAIMAN_OF_MSG_CATEGORY_WITH_ID_NOT_FOUND', $id), 'notice');
         unset($cids[$key]);
         continue;
       }
@@ -1476,7 +1478,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
       return false;
     }
 
-    JRequest::setVar('cid', $orphans);
+    $this->_mainframe->input->set('cid', $orphans);
 
     return $this->addOrphanedFolder();
   }
@@ -1489,7 +1491,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
    */
   public function addOrphanedFolder()
   {
-    $cids = JRequest::getVar('cid', array(), '', 'array');
+    $cids = $this->_mainframe->input->get('cid', array(), 'array');
 
     if(!count($cids))
     {
@@ -1506,7 +1508,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
     {
       if(!$orphan->load($id))
       {
-        JError::raiseNotice(500, JText::sprintf('COM_JOOMGALLERY_MAIMAN_OF_MSG_FOLDER_WITH_ID_NOT_FOUND', $id));
+        $this->_mainframe->enqueueMessage(JText::sprintf('COM_JOOMGALLERY_MAIMAN_OF_MSG_FOLDER_WITH_ID_NOT_FOUND', $id), 'notice');
         continue;
       }
 
@@ -1525,7 +1527,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
       $this->_db->setQuery($query);
       if(!$category = $this->_db->loadObject())
       {
-        JError::raiseNotice(500, JText::sprintf('COM_JOOMGALLERY_MAIMAN_OF_MSG_CORRUPT_CATEGORY_WITH_ID_NOT_FOUND', $id, $orphan->refid));
+        $this->_mainframe->enqueueMessage(JText::sprintf('COM_JOOMGALLERY_MAIMAN_OF_MSG_CORRUPT_CATEGORY_WITH_ID_NOT_FOUND', $id, $orphan->refid), 'notice');
         continue;
       }
 
@@ -1547,7 +1549,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
           }
           else
           {
-            JError::raiseNotice(500, JText::sprintf('COM_JOOMGALLERY_MAIMAN_OF_MSG_SUGGESTED_CATEGORY_NOT_CORRUPT', $id, $orphan->refid));
+            $this->_mainframe->enqueueMessage(JText::sprintf('COM_JOOMGALLERY_MAIMAN_OF_MSG_SUGGESTED_CATEGORY_NOT_CORRUPT', $id, $orphan->refid), 'notice');
             continue;
           }
         }
@@ -1559,7 +1561,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
 
       if(JFolder::move(JPath::clean($src), JPath::clean($dest)) !== true)
       {
-        JError::raiseWarning(500, JText::sprintf('COM_JOOMGALLERY_MAIMAN_OF_MSG_COULD_NOT_MOVE_FOLDER', $src, $dest));
+        $this->_mainframe->enqueueMessage(JText::sprintf('COM_JOOMGALLERY_MAIMAN_OF_MSG_COULD_NOT_MOVE_FOLDER', $src, $dest), 'error');
         continue;
       }
 
@@ -1572,7 +1574,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
             ->where('type != 0');
 
       $this->_db->setQuery($query);
-      if(!$this->_db->query())
+      if(!$this->_db->execute())
       {
         $this->setError($this->_db->getErrorMsg());
 
@@ -1601,7 +1603,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
    */
   public function applySuggestions()
   {
-    $cids = JRequest::getVar('cid', array(), 'post', 'array');
+    $cids = $this->_mainframe->input->post->get('cid', array(), 'array');
 
     if(!count($cids))
     {
@@ -1638,7 +1640,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
     $moved = 0;
     if(count($move))
     {
-      JRequest::setVar('cid', $move);
+      $this->_mainframe->input->set('cid', $move);
       $moved = $this->addOrphan();
       if($moved === false)
       {
@@ -1649,7 +1651,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
     $deleted = 0;
     if(count($delete))
     {
-      JRequest::setVar('cid', $delete);
+      $this->_mainframe->input->post->set('cid', $delete);
       $deleted = $this->deleteOrphan();
       if($deleted === false)
       {
@@ -1669,7 +1671,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
    */
   public function applyFolderSuggestions()
   {
-    $cids = JRequest::getVar('cid', array(), 'post', 'array');
+    $cids = $this->_mainframe->input->post->get('cid', array(), 'array');
 
     if(!count($cids))
     {
@@ -1705,7 +1707,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
     $moved = 0;
     if(count($move))
     {
-      JRequest::setVar('cid', $move);
+      $this->_mainframe->input->set('cid', $move);
       $moved = $this->addOrphanedFolder();
       if($moved === false)
       {
@@ -1716,7 +1718,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
     $deleted = 0;
     if(count($delete))
     {
-      JRequest::setVar('cid', $delete);
+      $this->_mainframe->input->post->set('cid', $delete);
       $deleted = $this->deleteOrphanedFolder();
       if($deleted === false)
       {
@@ -1735,8 +1737,8 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
    */
   public function create()
   {
-    $cids   = JRequest::getVar('cid', array(), '', 'array');
-    $types  = JRequest::getVar('type', array('thumb', 'img', 'orig'), '', 'array');
+    $cids   = $this->_mainframe->input->get('cid', array(), 'array');
+    $types  = $this->_mainframe->input->get('type', array('thumb', 'img', 'orig'), '', 'array');
 
     if(!count($cids))
     {
@@ -1782,7 +1784,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
               ->where('refid = '.$cid)
               ->where('type != 0');
         $this->_db->setQuery($query);
-        if(!$this->_db->query())
+        if(!$this->_db->execute())
         {
           $this->setError($this->_db->getErrorMsg());
 
@@ -1819,9 +1821,9 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
                 '._JOOM_TABLE_VOTES;
 
     $this->_db->setQuery($query);
-    if(!$this->_db->query())
+    if(!$this->_db->execute())
     {
-      JError::raiseWarning(500, $this->_db->getErrorMsg());
+      $this->_mainframe->enqueueMessage($this->_db->getErrorMsg(), 'error');
 
       return false;
     }
@@ -2233,21 +2235,21 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
     if(JFolder::exists($orig_path) && !JFolder::delete($orig_path))
     {
       $error = true;
-      JError::raiseWarning(500, JText::sprintf('COM_JOOMGALLERY_MAIMAN_MSG_ERROR_DELETING_DIRECTORY', $orig_path));
+      $this->_mainframe->enqueueMessage(JText::sprintf('COM_JOOMGALLERY_MAIMAN_MSG_ERROR_DELETING_DIRECTORY', $orig_path), 'error');
     }
 
     // Delete the folder of the category for the detail images
     if(JFolder::exists($img_path) && !JFolder::delete($img_path))
     {
       $error = true;
-      JError::raiseWarning(500, JText::sprintf('COM_JOOMGALLERY_MAIMAN_MSG_ERROR_DELETING_DIRECTORY', $img_path));
+      $this->_mainframe->enqueueMessage(JText::sprintf('COM_JOOMGALLERY_MAIMAN_MSG_ERROR_DELETING_DIRECTORY', $img_path), 'error');
     }
 
     // Delete the folder of the category for the thumbnails
     if(JFolder::exists($thumb_path) && !JFolder::delete($thumb_path))
     {
       $error = true;
-      JError::raiseWarning(500, JText::sprintf('COM_JOOMGALLERY_MAIMAN_MSG_ERROR_DELETING_DIRECTORY', $thumb_path));
+      $this->_mainframe->enqueueMessage(JText::sprintf('COM_JOOMGALLERY_MAIMAN_MSG_ERROR_DELETING_DIRECTORY', $thumb_path), 'error');
     }
 
     if($error)
@@ -2268,7 +2270,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
    * @param   string  $default    The default value for the variable if not found (optional)
    * @param   string  $type       Filter for the variable, for valid values see {@link JFilterInput::clean()} (optional)
    * @param   boolean $resetPage  If true, the limitstart in request is set to zero if the state has changed
-   * @return  The requested user state
+   * @return  mixed The requested user state
    * @since   2.0
    */
   public function getUserStateFromRequest($key, $request, $default = null, $type = 'none', $resetPage = true)
@@ -2276,11 +2278,11 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
     $app = JFactory::getApplication();
     $old_state = $app->getUserState($key);
     $cur_state = (!is_null($old_state)) ? $old_state : $default;
-    $new_state = JRequest::getVar($request, null, 'default', $type);
+    $new_state = $this->_mainframe->input->get($request, null, $type);
 
     if($cur_state != $new_state && !is_null($new_state) && !is_null($old_state) && $resetPage)
     {
-      JRequest::setVar('limitstart', 0);
+      $this->_mainframe->input->set('limitstart', 0);
     }
 
     // Save the new value only if it was set in this request.

--- a/administrator/components/com_joomgallery/models/maintenancecheck.php
+++ b/administrator/components/com_joomgallery/models/maintenancecheck.php
@@ -44,7 +44,7 @@ class JoomGalleryModelMaintenancecheck extends JoomGalleryModel
     $this->_db->truncateTable(_JOOM_TABLE_MAINTENANCE);
     $this->_db->truncateTable(_JOOM_TABLE_ORPHANS);
 
-    $this->_mainframe->setUserState('joom.maintenance.checkoriginals', JRequest::getBool('check_originals'));
+    $this->_mainframe->setUserState('joom.maintenance.checkoriginals', $this->_mainframe->input->getBool('check_originals'));
 
     // Prepare next step: Calculate an approximate value for the number of folders to parse
     $query = $this->_db->getQuery(true)
@@ -183,10 +183,10 @@ class JoomGalleryModelMaintenancecheck extends JoomGalleryModel
           $query->set("type = 'folder'");
           $query->set("fullpath = '".JPath::clean($new_folder, '/')."'");
           $this->_db->setQuery($query);
-          $this->_db->query();
+          $this->_db->execute();
         }
         //$this->_db->setQuery($query);
-        //$this->_db->query();
+        //$this->_db->execute();
       }
 
       // Collect all images of the current folder
@@ -210,7 +210,7 @@ class JoomGalleryModelMaintenancecheck extends JoomGalleryModel
           $query->values("'".$type."', '".JPath::clean($file, '/')."'");
         }
         $this->_db->setQuery($query);
-        $this->_db->query();
+        $this->_db->execute();
       }
 
       if(!$refresher->check())
@@ -312,7 +312,7 @@ class JoomGalleryModelMaintenancecheck extends JoomGalleryModel
                   ->where("fullpath = '".JPath::clean($file, '/')."'")
                   ->where("(type = 'thumb' OR type = 'img' OR type = 'orig')");
             $this->_db->setQuery($delete_query);
-            $this->_db->query();
+            $this->_db->execute();
           }
           else
           {
@@ -441,7 +441,7 @@ class JoomGalleryModelMaintenancecheck extends JoomGalleryModel
                   ->where("fullpath = '".JPath::clean($folder, '/')."'")
                   ->where("type = 'folder'");
             $this->_db->setQuery($delete_query);
-            $this->_db->query();
+            $this->_db->execute();
           }
           else
           {
@@ -552,7 +552,7 @@ class JoomGalleryModelMaintenancecheck extends JoomGalleryModel
               ->set("title = '".$suggestion->imgtitle."'")
               ->where('id = '.$file->id);
         $this->_db->setQuery($query);
-        $this->_db->query();
+        $this->_db->execute();
 
         if($suggestion->orphan_id)
         {
@@ -561,7 +561,7 @@ class JoomGalleryModelMaintenancecheck extends JoomGalleryModel
                 ->set($file->type.'orphan = '.$file->id)
                 ->where('id = '.$suggestion->orphan_id);
           $this->_db->setQuery($query);
-          $this->_db->query();
+          $this->_db->execute();
         }
       }
 
@@ -681,7 +681,7 @@ class JoomGalleryModelMaintenancecheck extends JoomGalleryModel
                 ->set("title = '".$suggestion->name."'")
                 ->where('id = '.$folder->id);
           $this->_db->setQuery($query);
-          $this->_db->query();
+          $this->_db->execute();
 
           if($suggestion->orphan_id)
           {
@@ -690,7 +690,7 @@ class JoomGalleryModelMaintenancecheck extends JoomGalleryModel
                   ->set($type.'orphan = '.$folder->id)
                   ->where('id = '.$suggestion->orphan_id);
             $this->_db->setQuery($query);
-            $this->_db->query();
+            $this->_db->execute();
           }
         }
       }

--- a/administrator/components/com_joomgallery/models/mini.php
+++ b/administrator/components/com_joomgallery/models/mini.php
@@ -49,8 +49,8 @@ class JoomGalleryModelMini extends JoomGalleryModel
     // Let's load the data if it doesn't already exist
     if(empty($this->_images))
     {
-      $limitstart = JRequest::getInt('limitstart');
-      $limit      = JRequest::getInt('limit');
+      $limitstart = $this->_mainframe->input->getInt('limitstart');
+      $limit      = $this->_mainframe->input->getInt('limit');
 
       $query = $this->_buildQuery();
 
@@ -116,7 +116,7 @@ class JoomGalleryModelMini extends JoomGalleryModel
 
     // Filter by category
     $catid  = $this->_mainframe->getUserStateFromRequest('joom.mini.catid', 'catid', 0, 'int');
-    if($catid || JRequest::getCmd('type') == 'category')
+    if($catid || $this->_mainframe->input->getCmd('type') == 'category')
     {
       $query->where('jg.catid = '.$catid);
     }

--- a/administrator/components/com_joomgallery/models/move.php
+++ b/administrator/components/com_joomgallery/models/move.php
@@ -43,7 +43,7 @@ class JoomGalleryModelMove extends JoomGalleryModel
    */
   protected function _buildQuery()
   {
-    $cids = JRequest::getVar('cid', array(0), 'post', 'array');
+    $cids = $this->_mainframe->input->post->get('cid', array(0), 'array');
 
     $query = $this->_db->getQuery(true)
           ->select('*')

--- a/administrator/components/com_joomgallery/script.php
+++ b/administrator/components/com_joomgallery/script.php
@@ -41,9 +41,9 @@ class Com_JoomGalleryInstallerScript
    */
   public function preflight($type = 'install')
   {
-    if(version_compare(JVERSION, '4.0', 'ge') || version_compare(JVERSION, '3.0', 'lt'))
+    if(version_compare(JVERSION, '5.0', 'ge') || version_compare(JVERSION, '3.0', 'lt'))
     {
-      JError::raiseWarning(500, 'JoomGallery 3.x is only compatible to Joomla! 3.x');
+      JFactory::getApplication()->enqueueMessage('JoomGallery 4.x is only compatible to Joomla! 4.x', 'error');
 
       return false;
     }
@@ -93,6 +93,7 @@ class Com_JoomGalleryInstallerScript
 
     $row = JTable::getInstance('module');
     $row->title     = 'JoomGallery News';
+    $row->content   = '';
     $row->ordering  = 1;
     $row->position  = 'joom_cpanel';
     $row->published = 1;
@@ -123,7 +124,7 @@ class Com_JoomGalleryInstallerScript
     $query->set('moduleid = '.$row->id);
     $query->set('menuid = 0');
     $db->setQuery($query);
-    if(!$db->query())
+    if(!$db->execute())
     {
       $app->enqueueMessage(JText::_('Unable to assign feed module!'), 'error');
     }
@@ -177,7 +178,7 @@ class Com_JoomGalleryInstallerScript
     {
       if(!JFile::delete(JPATH_ROOT.'/media/joomgallery/css/joom_settings.temp.css'))
       {
-        JError::raiseWarning(500, JText::_('Unable to delete temporary joom_settings.temp.css!'));
+        JFactory::getApplication()->enqueueMessage(JText::_('Unable to delete temporary joom_settings.temp.css!'), 'error');
 
         $error = true;
       }
@@ -377,7 +378,7 @@ class Com_JoomGalleryInstallerScript
         <a title="Languages" class="btn btn-primary" onclick="location.href='index.php?option=com_joomgallery&controller=help'; return false;" href="#">Languages</a>
       </p>
     </div>
-    <?php JHtml::_('bootstrap.modal', 'jg-changelog-popup'); ?>
+    <?php JHtmlBootstrap::renderModal('jg-changelog-popup'); ?>
     <div class="modal hide fade" tabindex="-1" role="dialog" aria-labelledby="PopupChangelogModalLabel" aria-hidden="true" id="jg-changelog-popup">
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>

--- a/administrator/components/com_joomgallery/tables/joomgallerycategories.php
+++ b/administrator/components/com_joomgallery/tables/joomgallerycategories.php
@@ -288,7 +288,7 @@ class TableJoomgalleryCategories extends JTableNested
           ->set('published = '.(int) $this->published)
           ->where('cid IN ('.implode(',', $cats).')');
     $this->_db->setQuery($query);
-    if(!$this->_db->query())
+    if(!$this->_db->execute())
     {
       $this->setError($this->_db->getErrorMsg());
 
@@ -316,7 +316,7 @@ class TableJoomgalleryCategories extends JTableNested
             ->set('in_hidden = '.(int) ($this->hidden || $this->in_hidden))
             ->where('cid IN ('.implode(',', $cats).')');
       $this->_db->setQuery($query);
-      if(!$this->_db->query())
+      if(!$this->_db->execute())
       {
         $this->setError($this->_db->getErrorMsg());
 
@@ -469,7 +469,7 @@ class TableJoomgalleryCategories extends JTableNested
     $this->_db->setQuery($query);
 
     // If there is an update failure, return false to break out of the recursion.
-    if(!$this->_db->query())
+    if(!$this->_db->execute())
     {
       $e = new JException(JText::sprintf('JLIB_DATABASE_ERROR_REBUILD_FAILED', get_class($this), $this->_db->getErrorMsg()));
       $this->setError($e);

--- a/administrator/components/com_joomgallery/tables/joomgalleryconfig.php
+++ b/administrator/components/com_joomgallery/tables/joomgalleryconfig.php
@@ -574,7 +574,7 @@ class TableJoomgalleryConfig extends JTable
 
     if($corrected)
     {
-      JError::raiseNotice(500, JText::_('COM_JOOMGALLERY_CONFIG_MSG_SETTINGS_FOR_SPECIALCHARS_CORRECTED'));
+      JFactory::getApplication()->enqueueMessage(JText::_('COM_JOOMGALLERY_CONFIG_MSG_SETTINGS_FOR_SPECIALCHARS_CORRECTED'), 'notice');
     }
 
     return true;

--- a/administrator/components/com_joomgallery/tables/joomgalleryimages.php
+++ b/administrator/components/com_joomgallery/tables/joomgalleryimages.php
@@ -122,11 +122,11 @@ class TableJoomgalleryImages extends JTable
           $this->published = 0;
           if($this->id)
           {
-            JError::raiseNotice('100', JText::sprintf('COM_JOOMGALLERY_COMMON_NOT_ALLOWED_TO_PUBLISH_IMAGE', $this->id));
+            JFactory::getApplication()->enqueueMessage(JText::sprintf('COM_JOOMGALLERY_COMMON_NOT_ALLOWED_TO_PUBLISH_IMAGE', $this->id),'notice');
           }
           else
           {
-            JError::raiseNotice('100', JText::_('COM_JOOMGALLERY_COMMON_NOT_ALLOWED_TO_PUBLISH_NEW_IMAGE'));
+            JFactory::getApplication()->enqueueMessage(JText::_('COM_JOOMGALLERY_COMMON_NOT_ALLOWED_TO_PUBLISH_NEW_IMAGE'),'notice');
           }
         }
       }
@@ -230,7 +230,7 @@ class TableJoomgalleryImages extends JTable
           ->set('thumbnail = 0')
           ->where('thumbnail = '.$pk);
     $this->_db->setQuery($query);
-    if(!$this->_db->query())
+    if(!$this->_db->execute())
     {
       $this->setError($this->_db->getErrorMsg());
 

--- a/administrator/components/com_joomgallery/view.php
+++ b/administrator/components/com_joomgallery/view.php
@@ -13,8 +13,6 @@
 
 defined('_JEXEC') or die('Direct Access to this location is not allowed.');
 
-jimport( 'joomla.application.component.view');
-
 /**
  * Parent HTML View Class for JoomGallery
  *
@@ -29,7 +27,7 @@ class JoomGalleryView extends JViewLegacy
    * @access  protected
    * @var     object
    */
-  var $_mainframe;
+  protected $_mainframe;
 
   /**
    * JoomConfig object
@@ -37,7 +35,7 @@ class JoomGalleryView extends JViewLegacy
    * @access  protected
    * @var     object
    */
-  var $_config;
+  protected $_config;
 
   /**
    * JoomAmbit object
@@ -45,7 +43,7 @@ class JoomGalleryView extends JViewLegacy
    * @access  protected
    * @var     object
    */
-  var $_ambit;
+  protected $_ambit;
 
   /**
    * JUser object, holds the current user data
@@ -53,7 +51,7 @@ class JoomGalleryView extends JViewLegacy
    * @access  protected
    * @var     object
    */
-  var $_user;
+  protected $_user;
 
   /**
    * JDocument object
@@ -61,7 +59,7 @@ class JoomGalleryView extends JViewLegacy
    * @access  protected
    * @var     object
    */
-  var $_doc;
+  protected $_doc;
 
   /**
    * Constructor
@@ -76,8 +74,7 @@ class JoomGalleryView extends JViewLegacy
 
     $this->_ambit     = JoomAmbit::getInstance();
     $this->_config    = JoomConfig::getInstance();
-
-    $this->_mainframe = JFactory::getApplication('administrator');
+    $this->_mainframe = JFactory::getApplication();
     $this->_user      = JFactory::getUser();
     $this->_doc       = JFactory::getDocument();
 
@@ -93,8 +90,8 @@ class JoomGalleryView extends JViewLegacy
     // Check for available updates
     if(!$checked = $this->_mainframe->getUserState('joom.update.checked'))
     {
-      $controller = JRequest::getCmd('controller');
-      if($this->_config->get('jg_checkupdate') && $controller && $controller != 'control')
+      $controller = $this->_mainframe->input->getCmd('controller');
+      if($this->_config->jg_checkupdate && $controller && $controller != 'control')
       {
         $dated_extensions = JoomExtensions::checkUpdate();
         if(count($dated_extensions))
@@ -112,7 +109,7 @@ class JoomGalleryView extends JViewLegacy
     {
       if($checked == -1)
       {
-        $controller = JRequest::getCmd('controller');
+        $controller = $this->_mainframe->input->getCmd('controller');
         if($controller && $controller != 'control')
         {
           $this->_mainframe->enqueueMessage(JText::_('COM_JOOMGALLERY_ADMENU_SYSTEM_NOT_UPTODATE'), 'warning');

--- a/administrator/components/com_joomgallery/views/batchupload/tmpl/default.php
+++ b/administrator/components/com_joomgallery/views/batchupload/tmpl/default.php
@@ -1,7 +1,7 @@
 <?php defined('_JEXEC') or die('Direct Access to this location is not allowed.');
 JHtml::_('behavior.formvalidation');
 JHtml::_('bootstrap.tooltip'); ?>
-<form action="index.php" method="post" name="adminForm" id="upload-form" enctype="multipart/form-data" class="form-validate form-horizontal" onsubmit="if(this.task.value == 'upload' && !document.formvalidator.isValid(document.id('upload-form'))){alert('<?php echo JText::_('JGLOBAL_VALIDATION_FORM_FAILED', true); ?>');return false;}">
+<form action="index.php" method="post" name="adminForm" id="upload-form" enctype="multipart/form-data" class="form-validate form-horizontal" onsubmit="if(document.getElementsByName('task')[0].value == 'upload' && !document.formvalidator.isValid(document.id('upload-form'))){alert('<?php echo JText::_('JGLOBAL_VALIDATION_FORM_FAILED', true); ?>');return false;}">
 <?php if(!empty($this->sidebar)): ?>
   <div id="j-sidebar-container" class="span2">
     <?php echo $this->sidebar; ?>

--- a/administrator/components/com_joomgallery/views/category/tmpl/form.php
+++ b/administrator/components/com_joomgallery/views/category/tmpl/form.php
@@ -1,8 +1,8 @@
 <?php defined('_JEXEC') or die('Restricted access');?>
-<script language="javascript" type="text/javascript">
+<script type="text/javascript">
   Joomla.submitbutton = function(task)
   {
-    var form = document.id('item-form');
+    var form = document.getElementById('item-form');
     if (task == 'cancel' || document.formvalidator.isValid(form)) {
       <?php echo $this->form->getField('description')->save(); ?>
       Joomla.submitform(task, form);
@@ -10,8 +10,8 @@
     else {
       var msg = new Array();
       msg.push('<?php echo JText::_('JGLOBAL_VALIDATION_FORM_FAILED', true);?>');
-      if (form.name.hasClass('invalid')) {
-          msg.push('<?php echo JText::_('COM_JOOMGALLERY_CATMAN_ALERT_CATEGORY_MUST_HAVE_TITLE', true);?>');
+      if (form.getElementById('jform_title').hasClass('invalid')) {
+        msg.push('<?php echo JText::_('COM_JOOMGALLERY_CATMAN_ALERT_CATEGORY_MUST_HAVE_TITLE', true);?>');
       }
       alert(msg.join('\n'));
     }

--- a/administrator/components/com_joomgallery/views/category/view.html.php
+++ b/administrator/components/com_joomgallery/views/category/view.html.php
@@ -31,18 +31,18 @@ class JoomGalleryViewCategory extends JoomGalleryView
   public function display($tpl = null)
   {
     // Get the category data
-    $item = $this->get('Data');
+    $this->item = $this->get('Data');
 
-    $isNew = ($item->cid < 1);
-    if($isNew)
+    $this->isNew = ($this->item->cid < 1);
+    if($this->isNew)
     {
-      $item->published = 1;
+      $this->item->published = 1;
     }
 
     // Get image source for the thumbnail preview
-    if($item->thumbnail && $item->thumbnail_available)
+    if($this->item->thumbnail && $this->item->thumbnail_available)
     {
-      $imgsource = $this->_ambit->getImg('thumb_url', $item->thumbnail);
+      $imgsource = $this->_ambit->getImg('thumb_url', $this->item->thumbnail);
     }
     else
     {
@@ -50,67 +50,64 @@ class JoomGalleryViewCategory extends JoomGalleryView
     }
 
     // Get the form and fill the fields
-    $form = $this->get('Form');
-    if(!$isNew)
+    $this->form = $this->get('Form');
+    if(!$this->isNew)
     {
       // Add additional attribute for category form field to exclude current
       // category id from select box
-      $form->setFieldAttribute('parent_id', 'exclude', $item->cid);
+      $this->form->setFieldAttribute('parent_id', 'exclude', $this->item->cid);
     }
 
     // Ordering box is not available if option for performance improvement has been enabled
     if(!$this->_config->get('jg_disableunrequiredchecks'))
     {
       // Set some additional attributes for the ordering select box
-      $form->setFieldAttribute('ordering', 'originalOrder', $item->cid);
-      $form->setFieldAttribute('ordering', 'originalParent', $item->parent_id == 1 ? 0 : $item->parent_id);
-      $form->setFieldAttribute('ordering', 'orderings', base64_encode(serialize($this->getModel()->getOrderings($item->cid ? $item->parent_id : null))));
+      $this->form->setFieldAttribute('ordering', 'originalOrder', $this->item->cid);
+      $this->form->setFieldAttribute('ordering', 'originalParent', $this->item->parent_id == 1 ? 0 : $this->item->parent_id);
+      $this->form->setFieldAttribute('ordering', 'orderings', base64_encode(serialize($this->getModel()->getOrderings($this->item->cid ? $this->item->parent_id : null))));
       // Perhaps there is a better way to set the field attribute
-      $parent_field = $this->_findFieldByFieldName($form, 'parent_id');
+      $parent_field = $this->_findFieldByFieldName($this->form, 'parent_id');
       if($parent_field !== false)
       {
-        $form->setFieldAttribute('ordering', 'parent_id', $parent_field->id);
+        $this->form->setFieldAttribute('ordering', 'parent_id', $parent_field->id);
       }
     }
 
-    $imagelib_field = $this->_findFieldByFieldName($form, 'imagelib');
+    $imagelib_field = $this->_findFieldByFieldName($this->form, 'imagelib');
     // Set additional attribute for the thumbnail select box
     if($imagelib_field !== false)
     {
-      $form->setFieldAttribute('thumbnail', 'imagelib_id', $imagelib_field->id);
+      $this->form->setFieldAttribute('thumbnail', 'imagelib_id', $imagelib_field->id);
     }
 
     // Set maximum allowed user count to switch from listbox to modal popup selection
-    $form->setFieldAttribute('owner', 'useListboxMaxUserCount', $this->_config->get('jg_use_listbox_max_user_count'));
+    $this->form->setFieldAttribute('owner', 'useListboxMaxUserCount', $this->_config->get('jg_use_listbox_max_user_count'));
 
     // Bind the data to the form
-    $form->bind($item);
+    $this->form->bind($this->item);
 
     // Set thumbnail image source for thumbnail preview form field
-    $form->setValue('imagelib', null, $imgsource);
+    $this->form->setValue('imagelib', null, $imgsource);
 
     // Set immutable fields
-    if($item->published)
+    if($this->item->published)
     {
-      $form->setValue('publishhiddenstate', null, $item->hidden ? JText::_('COM_JOOMGALLERY_COMMON_PUBLISHED_BUT_HIDDEN') : JText::_('COM_JOOMGALLERY_COMMON_STATE_PUBLISHED') );
+      $this->form->setValue('publishhiddenstate', null, $this->item->hidden ? JText::_('COM_JOOMGALLERY_COMMON_PUBLISHED_BUT_HIDDEN') : JText::_('COM_JOOMGALLERY_COMMON_STATE_PUBLISHED') );
     }
     else
     {
-      $form->setValue('publishhiddenstate', null, JText::_('COM_JOOMGALLERY_COMMON_STATE_UNPUBLISHED'));
+      $this->form->setValue('publishhiddenstate', null, JText::_('COM_JOOMGALLERY_COMMON_STATE_UNPUBLISHED'));
     }
 
-    if($item->thumbnail && !$item->thumbnail_available)
+    if($this->item->thumbnail && !$this->item->thumbnail_available)
     {
-      $form->setValue('notice', null, JText::sprintf('COM_JOOMGALLERY_CATMAN_THUMBNAIL_NOT_AVAILABLE', $item->thumbnail));
+      $this->form->setValue('notice', null, JText::sprintf('COM_JOOMGALLERY_CATMAN_THUMBNAIL_NOT_AVAILABLE', $this->item->thumbnail));
     }
 
     JHtml::_('jquery.framework');
 
-    $this->assignRef('item', $item);
-    $this->assignRef('isNew', $isNew);
-    $this->assignRef('form', $form);
-
     $this->addToolbar();
+
     parent::display($tpl);
   }
 

--- a/administrator/components/com_joomgallery/views/config/tmpl/default.php
+++ b/administrator/components/com_joomgallery/views/config/tmpl/default.php
@@ -964,9 +964,9 @@ echo JHtml::_('tabs.end');
     <input type="hidden" name="task" value="" />
     <input type="hidden" name="boxchecked" value="0" />
 <?php if($this->_config->isExtended()): ?>
-    <input type="hidden" name="id" value="<?php echo !JRequest::getInt('group_id') ? JRequest::getInt('id') : 0; ?>" />
-    <input type="hidden" name="based_on" value="<?php echo JRequest::getInt('id'); ?>" />
-    <input type="hidden" name="group_id" value="<?php echo JRequest::getInt('group_id'); ?>" />
+    <input type="hidden" name="id" value="<?php echo !$this->_mainframe->input->getInt('group_id') ? $this->_mainframe->input->getInt('id') : 0; ?>" />
+    <input type="hidden" name="based_on" value="<?php echo $this->_mainframe->input->getInt('id'); ?>" />
+    <input type="hidden" name="group_id" value="<?php echo $this->_mainframe->input->getInt('group_id'); ?>" />
 <?php endif; ?>
     <?php JHtml::_('joomgallery.credits'); ?>
   </div>

--- a/administrator/components/com_joomgallery/views/config/view.html.php
+++ b/administrator/components/com_joomgallery/views/config/view.html.php
@@ -35,17 +35,17 @@ class JoomGalleryViewConfig extends JoomGalleryView
     $language->load(_JOOM_OPTION.'.exif', JPATH_SITE);
     $language->load(_JOOM_OPTION.'.iptc', JPATH_SITE);
 
-    $display = true;
+    $this->display = true;
     if($this->_config->isExtended())
     {
-      $config_id = JRequest::getInt('id');
+      $config_id = $this->_mainframe->input->getInt('id');
 
       // Overwrite config object with specified one
       $this->_config = JoomConfig::getInstance($config_id);
 
-      if(JRequest::getInt('group_id') || ($config_id && $config_id != 1))
+      if($this->_mainframe->input->getInt('group_id') || ($config_id && $config_id != 1))
       {
-        $display = false;
+        $this->display = false;
       }
     }
 
@@ -55,17 +55,17 @@ class JoomGalleryViewConfig extends JoomGalleryView
     // to be installed but not verified
     if($gdver > 0)
     {
-      $gdmsg = JText::sprintf('COM_JOOMGALLERY_CONFIG_GS_IP_GDLIB_INSTALLED', $gdver);
+      $this->gdmsg = JText::sprintf('COM_JOOMGALLERY_CONFIG_GS_IP_GDLIB_INSTALLED', $gdver);
     }
     else
     {
       if($gdver == -1)
       {
-        $gdmsg = JText::_('COM_JOOMGALLERY_CONFIG_GS_IP_GDLIB_NO_VERSION');
+        $this->gdmsg = JText::_('COM_JOOMGALLERY_CONFIG_GS_IP_GDLIB_NO_VERSION');
       }
       else
       {
-        $gdmsg = JText::_('COM_JOOMGALLERY_CONFIG_GS_IP_GDLIB_NOT_INSTALLED') .
+        $this->gdmsg = JText::_('COM_JOOMGALLERY_CONFIG_GS_IP_GDLIB_NOT_INSTALLED') .
                 '<a href="http://www.php.net/gd" target="_blank">http://www.php.net/gd</a>'
                 . JText::_('COM_JOOMGALLERY_GD_MORE_INFO');
       }
@@ -74,7 +74,7 @@ class JoomGalleryViewConfig extends JoomGalleryView
     // first check if exec() has been diabled in php.ini
     if($this->get('DisabledExec'))
     {
-      $immsg = JText::_('COM_JOOMGALLERY_CONFIG_GS_IP_IMAGIC_EXEC_DISABLED');
+      $this->immsg = JText::_('COM_JOOMGALLERY_CONFIG_GS_IP_IMAGIC_EXEC_DISABLED');
     }
     else
     {
@@ -82,31 +82,31 @@ class JoomGalleryViewConfig extends JoomGalleryView
       // Returns version, 0 if not installed or path not properly configured
       if($imver)
       {
-        $immsg = JText::_('COM_JOOMGALLERY_CONFIG_GS_IP_IMAGIC_INSTALLED') .  $imver;
+        $this->immsg = JText::_('COM_JOOMGALLERY_CONFIG_GS_IP_IMAGIC_INSTALLED') .  $imver;
         // Add the information that IM was detected automatically if path is empty
         if(!$this->_config->get('jg_impath'))
         {
-          $immsg .= JText::_('COM_JOOMGALLERY_CONFIG_GS_IP_IMAGIC_INSTALLED_AUTO') ;
+          $this->immsg .= JText::_('COM_JOOMGALLERY_CONFIG_GS_IP_IMAGIC_INSTALLED_AUTO') ;
         }
       }
       else
       {
-        $immsg = JText::_('COM_JOOMGALLERY_CONFIG_GS_IP_IMAGIC_NOT_INSTALLED');
+        $this->immsg = JText::_('COM_JOOMGALLERY_CONFIG_GS_IP_IMAGIC_NOT_INSTALLED');
       }
     }
 
     // Check the installation of Exif
-    $exifmsg = '';
+    $this->exifmsg = '';
     if(!extension_loaded('exif'))
     {
-      $exifmsg    = '<div style="color:#f00;font-weight:bold; text-align:center;">[' . JText::_('COM_JOOMGALLERY_CONFIG_DV_ED_NOT_INSTALLED') . ' ' . JText::_('COM_JOOMGALLERY_CONFIG_DV_ED_NO_OPTIONS') . ']</div>';
+      $this->exifmsg    = '<div style="color:#f00;font-weight:bold; text-align:center;">[' . JText::_('COM_JOOMGALLERY_CONFIG_DV_ED_NOT_INSTALLED') . ' ' . JText::_('COM_JOOMGALLERY_CONFIG_DV_ED_NO_OPTIONS') . ']</div>';
     }
     else
     {
-      $exifmsg    = '<div style="color:#080; text-align:center;">[' . JText::_('COM_JOOMGALLERY_CONFIG_DV_ED_INSTALLED') . ']</div>';
+      $this->exifmsg    = '<div style="color:#080; text-align:center;">[' . JText::_('COM_JOOMGALLERY_CONFIG_DV_ED_INSTALLED') . ']</div>';
       if(!function_exists('exif_read_data'))
       {
-        $exifmsg = '<div style="color:#f00;font-weight:bold; text-align:center;">[' . JText::_('COM_JOOMGALLERY_CONFIG_DV_ED_INSTALLED_BUT') . ' ' . JText::_('COM_JOOMGALLERY_CONFIG_DV_ED_NO_OPTIONS') . ']</div>';
+        $this->exifmsg = '<div style="color:#f00;font-weight:bold; text-align:center;">[' . JText::_('COM_JOOMGALLERY_CONFIG_DV_ED_INSTALLED_BUT') . ' ' . JText::_('COM_JOOMGALLERY_CONFIG_DV_ED_NO_OPTIONS') . ']</div>';
       }
     }
 
@@ -120,61 +120,61 @@ class JoomGalleryViewConfig extends JoomGalleryView
 
     if(is_writeable($this->getPath('img')))
     {
-      $write_pathimages = $writeable;
+      $this->write_pathimages = $writeable;
     }
     else
     {
-      $write_pathimages = $unwriteable;
+      $this->write_pathimages = $unwriteable;
     }
     if(is_writeable($this->getPath('orig')))
     {
-      $write_pathoriginalimages = $writeable;
+      $this->write_pathoriginalimages = $writeable;
     }
     else
     {
-      $write_pathoriginalimages = $unwriteable;
+      $this->write_pathoriginalimages = $unwriteable;
     }
     if(is_writeable($this->getPath('thumb')))
     {
-      $write_paththumbs = $writeable;
+      $this->write_paththumbs = $writeable;
     }
     else
     {
-      $write_paththumbs = $unwriteable;
+      $this->write_paththumbs = $unwriteable;
     }
     if(is_writeable($this->getPath('ftp')))
     {
-      $write_pathftpupload = $writeable;
+      $this->write_pathftpupload = $writeable;
     }
     else
     {
-      $write_pathftpupload = $unwriteable;
+      $this->write_pathftpupload = $unwriteable;
     }
     if(is_writeable($this->getPath('temp')))
     {
-      $write_pathtemp = $writeable;
+      $this->write_pathtemp = $writeable;
     }
     else
     {
-      $write_pathtemp = $unwriteable;
+      $this->write_pathtemp = $unwriteable;
     }
     if(is_writeable($this->getPath('wtm')))
     {
-      $write_pathwm = $writeable;
+      $this->write_pathwm = $writeable;
     }
     else
     {
-      $write_pathwm = $unwriteable;
+      $this->write_pathwm = $unwriteable;
     }
     if(is_file($this->getPath('wtm').'/'.$this->_config->get('jg_wmfile')))
     {
-      $wmfilemsg = '<span style="color:#080;">'
+      $this->wmfilemsg = '<span style="color:#080;">'
         . JText::_('COM_JOOMGALLERY_CONFIG_GS_PD_FILE_EXIST') .
         '</span>';
     }
     else
     {
-      $wmfilemsg = '<span style="color:#f00;">'
+      $this->wmfilemsg = '<span style="color:#f00;">'
         . JText::_('COM_JOOMGALLERY_CONFIG_GS_PD_FILE_NOT_EXIST') .
         '</span>';
     }
@@ -182,11 +182,11 @@ class JoomGalleryViewConfig extends JoomGalleryView
     // Check whether CSS file (joom_settings.css) is writeable
     if(is_writeable(JPATH_ROOT.'/media/joomgallery/css/'.$this->_config->getStyleSheetName()))
     {
-      $cssfilemsg = '<div style="color:#080; text-align:center;">['.JText::_('COM_JOOMGALLERY_CONFIG_GS_PD_CSS_CONFIGURATION_WRITEABLE').']</div>';
+      $this->cssfilemsg = '<div style="color:#080; text-align:center;">['.JText::_('COM_JOOMGALLERY_CONFIG_GS_PD_CSS_CONFIGURATION_WRITEABLE').']</div>';
     }
     else
     {
-      $cssfilemsg = '<div style="color:#f00;font-weight:bold; text-align:center;">['.JText::_('COM_JOOMGALLERY_CONFIG_GS_PD_CSS_CONFIGURATION_NOT_WRITEABLE').' '.JText::_('COM_JOOMGALLERY_COMMON_CHECK_PERMISSIONS').']</div>';
+      $this->cssfilemsg = '<div style="color:#f00;font-weight:bold; text-align:center;">['.JText::_('COM_JOOMGALLERY_CONFIG_GS_PD_CSS_CONFIGURATION_NOT_WRITEABLE').' '.JText::_('COM_JOOMGALLERY_COMMON_CHECK_PERMISSIONS').']</div>';
     }
 
     // Exif
@@ -196,7 +196,7 @@ class JoomGalleryViewConfig extends JoomGalleryView
     $subifdtags = explode(',', $this->_config->get('jg_subifdtags'));
     $gpstags    = explode(',', $this->_config->get('jg_gpstags'));
 
-    $exif_definitions = array(
+    $this->exif_definitions = array(
       1 => array ('TAG' => 'IFD0', 'JG' => $ifdotags, 'NAME' => 'jg_ifdotags[]', 'HEAD' => JText::_('COM_JOOMGALLERY_IFD0TAGS')),
       2 => array ('TAG' => 'EXIF', 'JG' => $subifdtags, 'NAME' => 'jg_subifdtags[]', 'HEAD' => JText::_('COM_JOOMGALLERY_SUBIFDTAGS')),
       3 => array ('TAG' => 'GPS',  'JG' => $gpstags,  'NAME' => 'jg_gpstags[]',  'HEAD' => JText::_('COM_JOOMGALLERY_GPSTAGS'))
@@ -207,7 +207,7 @@ class JoomGalleryViewConfig extends JoomGalleryView
 
     $iptctags   = explode(',', $this->_config->get('jg_iptctags'));
 
-    $iptc_definitions = array(
+    $this->iptc_definitions = array(
     1 => array ('TAG' => 'IPTC', 'JG' => $iptctags, 'NAME' => 'jg_iptctags[]', 'HEAD' => JText::_('COM_JOOMGALLERY_IPTCTAGS')),
     );
 
@@ -216,22 +216,8 @@ class JoomGalleryViewConfig extends JoomGalleryView
 
     JText::script('COM_JOOMGALLERY_CONFIG_GS_PD_ALERT_THUMBNAIL_PATH_SUPPORT');
 
-    $this->assignRef('display',                   $display);
-    $this->assignRef('cssfilemsg',                $cssfilemsg);
-    $this->assignRef('exifmsg',                   $exifmsg);
-    $this->assignRef('gdmsg',                     $gdmsg);
-    $this->assignRef('immsg',                     $immsg);
-    $this->assignRef('write_pathimages',          $write_pathimages);
-    $this->assignRef('write_pathoriginalimages',  $write_pathoriginalimages);
-    $this->assignRef('write_paththumbs',          $write_paththumbs);
-    $this->assignRef('write_pathftpupload',       $write_pathftpupload);
-    $this->assignRef('write_pathtemp',            $write_pathtemp);
-    $this->assignRef('write_pathwm',              $write_pathwm);
-    $this->assignRef('wmfilemsg',                 $wmfilemsg);
-    $this->assignRef('exif_definitions',          $exif_definitions);
-    $this->assignRef('exif_config_array',         $exif_config_array);
-    $this->assignRef('iptc_definitions',          $iptc_definitions);
-    $this->assignRef('iptc_config_array',         $iptc_config_array);
+    $this->exif_config_array =& $exif_config_array;
+    $this->iptc_config_array =& $iptc_config_array;
 
     $this->addToolbar();
 
@@ -249,7 +235,7 @@ class JoomGalleryViewConfig extends JoomGalleryView
     if($this->_config->isExtended())
     {
       $config_title = $this->get('ConfigTitle');
-      if(JRequest::getInt('id') == 1)
+      if($this->_mainframe->input->getInt('id') == 1)
       {
         $config_title = JText::sprintf('COM_JOOMGALLERY_CONFIGS_DEFAULT_TITLE', $config_title);
       }

--- a/administrator/components/com_joomgallery/views/control/view.html.php
+++ b/administrator/components/com_joomgallery/views/control/view.html.php
@@ -56,23 +56,20 @@ class JoomGalleryViewControl extends JoomGalleryView
 
     if($this->_config->get('jg_checkupdate'))
     {
-      $available_extensions = JoomExtensions::getAvailableExtensions();
+      $this->available_extensions = JoomExtensions::getAvailableExtensions();
       $this->params->set('url_fopen_allowed', @ini_get('allow_url_fopen'));
       $this->params->set('curl_loaded', extension_loaded('curl'));
 
       // If there weren't any available extensions found
       // loading the RSS feed wasn't successful
-      if(count($available_extensions))
+      if(count($this->available_extensions))
       {
-        $installed_extensions = JoomExtensions::getInstalledExtensions();
-        $this->assignRef('available_extensions',  $available_extensions);
-        $this->assignRef('installed_extensions',  $installed_extensions);
+        $this->installed_extensions = JoomExtensions::getInstalledExtensions();
         $this->params->set('show_available_extensions', 1);
 
-        $dated_extensions = JoomExtensions::checkUpdate();
-        if(count($dated_extensions))
+        $this->dated_extensions = JoomExtensions::checkUpdate();
+        if(count($this->dated_extensions))
         {
-          $this->assignRef('dated_extensions', $dated_extensions);
           $this->params->set('dated_extensions', 1);
         }
         else

--- a/administrator/components/com_joomgallery/views/cssedit/view.html.php
+++ b/administrator/components/com_joomgallery/views/cssedit/view.html.php
@@ -13,8 +13,6 @@
 
 defined('_JEXEC') or die('Direct Access to this location is not allowed.');
 
-jimport( 'joomla.application.component.view' );
-
 /**
  * HTML View class for the CSS edit view
  *
@@ -46,47 +44,43 @@ class JoomGalleryViewCssedit extends JoomGalleryView
 
       JToolBarHelper::deleteList(JText::_('COM_JOOMGALLERY_CSSMAN_CSS_CONFIRM_DELETE', true), 'remove', 'COM_JOOMGALLERY_CSSMAN_TOOLBAR_DELETE_CSS');
 
-      $file = $path.'joom_local.css';
+      $this->file = $path.'joom_local.css';
 
-      if(!is_writable($file))
+      if(!is_writable($this->file))
       {
-        JError::raiseNotice(111, JText::_('COM_JOOMGALLERY_CSSMAN_CSS_WARNING_PERMS'));
+        $this->_mainframe->enqueueMessage(JText::_('COM_JOOMGALLERY_CSSMAN_CSS_WARNING_PERMS'), 'notice');
       }
 
-      $edit = true;
+      $this->edit = true;
     }
     else
     {
       $title .= ' ('.JText::_('COM_JOOMGALLERY_COMMON_TOOLBAR_NEW').')';
 
-      $file = $path.'joom_local.css.README';
+      $this->file = $path.'joom_local.css.README';
 
       if(!is_writable($path))
       {
-        JError::raiseNotice(111, JText::_('COM_JOOMGALLERY_CSSMAN_CSS_WARNING_PERMS'));
+        $this->_mainframe->enqueueMessage(JText::_('COM_JOOMGALLERY_CSSMAN_CSS_WARNING_PERMS'), 'notice');
       }
 
-      $edit = false;
+      $this->edit = false;
     }
 
     JToolBarHelper::title($title, 'file');
 
-    $content =  JFile::read($file);
-    if($content === false)
+    $this->content =  file_get_contents($this->file);
+    if($this->content === false)
     {
       // Unable to read the file
-      JError::raiseWarning(111, JText::_('COM_JOOMGALLERY_CSSMAN_CSS_ERROR_READING') . $file);
+      $this->_mainframe->enqueueMessage(JText::_('COM_JOOMGALLERY_CSSMAN_CSS_ERROR_READING') . $this->file, 'error');
     }
     else
     {
-      $content = htmlspecialchars($content, ENT_QUOTES, 'UTF-8');
+      $this->content = htmlspecialchars($this->content, ENT_QUOTES, 'UTF-8');
     }
 
-    $file = $path.'joom_local.css';
-
-    $this->assignRef('content', $content);
-    $this->assignRef('edit',    $edit);
-    $this->assignRef('file',    $file);
+    $this->file = $path.'joom_local.css';
 
     $this->sidebar = JHtmlSidebar::render();
 

--- a/administrator/components/com_joomgallery/views/editimages/tmpl/form.php
+++ b/administrator/components/com_joomgallery/views/editimages/tmpl/form.php
@@ -6,10 +6,10 @@ JHtml::_('behavior.keepalive');
 JHtml::_('formbehavior.chosen', 'select');
 
 ?>
-<script language="javascript" type="text/javascript">
+<script type="text/javascript">
 Joomla.submitbutton = function(task)
 {
-  var form = document.id('editimages-form');
+  var form = document.getElementById('editimages-form');
   if(task == 'cancel' || document.formvalidator.isValid(form)) {
     <?php echo $this->form->getField('imgtext')->save(); ?>
     Joomla.submitform(task, form);
@@ -17,10 +17,10 @@ Joomla.submitbutton = function(task)
   else {
     var msg = new Array();
     msg.push('<?php echo JText::_('JGLOBAL_VALIDATION_FORM_FAILED', true);?>');
-    if(form.imgtitle.hasClass('invalid')) {
+    if(form.getElementById('jform_imgtitle').hasClass('invalid')) {
         msg.push('<?php echo JText::_('COM_JOOMGALLERY_COMMON_ALERT_IMAGE_MUST_HAVE_TITLE', true); ?>');
     }
-    if(form.catid.hasClass('invalid')) {
+    if(form.getElementById('jform_catid').hasClass('invalid')) {
       msg.push('<?php echo JText::_('COM_JOOMGALLERY_COMMON_ALERT_YOU_MUST_SELECT_CATEGORY', true);?>');
     }
     alert(msg.join('\n'));

--- a/administrator/components/com_joomgallery/views/editimages/view.html.php
+++ b/administrator/components/com_joomgallery/views/editimages/view.html.php
@@ -31,30 +31,27 @@ class JoomGalleryViewEditimages extends JoomGalleryView
    */
   function display($tpl = null)
   {
-    $items = $this->get('Images');
+    $this->items = $this->get('Images');
 
-    $cids = JRequest::getVar('cid', array(), '', 'array');
-    $cids = implode(',', $cids);
+    $this->cids = $this->_mainframe->input->get('cid', array(), 'array');
+    $this->cids = implode(',', $this->cids);
 
     // Get the form and fill the fields
-    $form = $this->get('Form');
+    $this->form = $this->get('Form');
 
     // Set maximum allowed user count to switch from listbox to modal popup selection
-    $form->setFieldAttribute('owner', 'useListboxMaxUserCount', $this->_config->get('jg_use_listbox_max_user_count'));
+    $this->form->setFieldAttribute('owner', 'useListboxMaxUserCount', $this->_config->get('jg_use_listbox_max_user_count'));
 
     // Bind the data to the form
-    $form->bind($items[0]);
+    $this->form->bind($this->items[0]);
 
     // Set some form fields manually
-    $form->setValue('txtclearhits', null, JText::_('COM_JOOMGALLERY_IMGMAN_CLEAR_HITS_FOR_ALL_IMAGES'));
-    $form->setValue('txtclearvotes', null, JText::_('COM_JOOMGALLERY_IMGMAN_CLEAR_VOTES_FOR_ALL_IMAGES'));
-    $form->setValue('txtcleardownloads', null, JText::_('COM_JOOMGALLERY_IMGMAN_CLEAR_DOWNLOADS_FOR_ALL_IMAGES'));
-
-    $this->assignRef('items', $items);
-    $this->assignRef('cids',  $cids);
-    $this->assignRef('form',  $form);
+    $this->form->setValue('txtclearhits', null, JText::_('COM_JOOMGALLERY_IMGMAN_CLEAR_HITS_FOR_ALL_IMAGES'));
+    $this->form->setValue('txtclearvotes', null, JText::_('COM_JOOMGALLERY_IMGMAN_CLEAR_VOTES_FOR_ALL_IMAGES'));
+    $this->form->setValue('txtcleardownloads', null, JText::_('COM_JOOMGALLERY_IMGMAN_CLEAR_DOWNLOADS_FOR_ALL_IMAGES'));
 
     $this->addToolbar();
+
     parent::display($tpl);
   }
 

--- a/administrator/components/com_joomgallery/views/ftpupload/tmpl/default.php
+++ b/administrator/components/com_joomgallery/views/ftpupload/tmpl/default.php
@@ -1,7 +1,7 @@
 <?php defined('_JEXEC') or die('Direct Access to this location is not allowed.');
 JHtml::_('behavior.formvalidation');
 JHtml::_('bootstrap.tooltip'); ?>
-<form action="index.php" method="post" name="adminForm" id="upload-form" enctype="multipart/form-data" class="form-validate form-horizontal" onsubmit="if(this.task.value == 'upload' && !document.formvalidator.isValid(document.id('upload-form'))){alert('<?php echo JText::_('JGLOBAL_VALIDATION_FORM_FAILED', true); ?>');return false;}">
+<form action="index.php" method="post" name="adminForm" id="upload-form" enctype="multipart/form-data" class="form-validate form-horizontal" onsubmit="if(document.getElementsByName('task')[0].value == 'upload' && !document.formvalidator.isValid(document.id('upload-form'))){alert('<?php echo JText::_('JGLOBAL_VALIDATION_FORM_FAILED', true); ?>');return false;}">
 <?php if(!empty($this->sidebar)): ?>
   <div id="j-sidebar-container" class="span2">
     <?php echo $this->sidebar; ?>

--- a/administrator/components/com_joomgallery/views/help/tmpl/default_changelog.php
+++ b/administrator/components/com_joomgallery/views/help/tmpl/default_changelog.php
@@ -1,5 +1,5 @@
 <?php defined('_JEXEC') or die('Direct Access to this location is not allowed.');
-JHtml::_('bootstrap.modal', 'jg-changelog-popup'); ?>
+JHtmlBootstrap::renderModal('jg-changelog-popup'); ?>
 <div class="modal hide fade" tabindex="-1" role="dialog" aria-labelledby="PopupChangelogModalLabel" aria-hidden="true" id="jg-changelog-popup">
   <div class="modal-header">
     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>

--- a/administrator/components/com_joomgallery/views/image/tmpl/form.php
+++ b/administrator/components/com_joomgallery/views/image/tmpl/form.php
@@ -6,10 +6,10 @@ JHtml::_('behavior.keepalive');
 JHtml::_('formbehavior.chosen', 'select');
 
 ?>
-<script language="javascript" type="text/javascript">
+<script type="text/javascript">
 Joomla.submitbutton = function(task)
 {
-  var form = document.id('item-form');
+  var form = document.getElementById('item-form');
   if(task == 'cancel' || task == 'resethits' || task == 'resetdownloads' || task == 'resetvotes' || document.formvalidator.isValid(form)) {
     <?php echo $this->form->getField('imgtext')->save(); ?>
     Joomla.submitform(task, form);
@@ -17,16 +17,16 @@ Joomla.submitbutton = function(task)
   else {
     var msg = new Array();
     msg.push('<?php echo JText::_('JGLOBAL_VALIDATION_FORM_FAILED', true); ?>');
-    if(form.imgtitle.hasClass('invalid')) {
+    if(form.getElementById('jform_title').hasClass('invalid')) {
         msg.push('<?php echo JText::_('COM_JOOMGALLERY_COMMON_ALERT_IMAGE_MUST_HAVE_TITLE', true); ?>');
     }
-    if(form.catid.hasClass('invalid')) {
+    if(form.getElementById('jform_catid').hasClass('invalid')) {
       msg.push('<?php echo JText::_('COM_JOOMGALLERY_COMMON_ALERT_YOU_MUST_SELECT_CATEGORY', true); ?>');
     }
-    if(form.imgfilename && form.imgfilename.hasClass('invalid')) {
+    if(form.getElementById('jform_imgfilename') && form.getElementById('jform_imgfilename').hasClass('invalid')) {
       msg.push('<?php echo JText::_('COM_JOOMGALLERY_IMGMAN_ALERT_SELECT_IMAGE_FILENAME', true); ?>');
     }
-    if(form.imgthumbname && form.imgthumbname.hasClass('invalid')) {
+    if(form.getElementById('jform_imgthumbname') && form.getElementById('jform_imgthumbname').hasClass('invalid')) {
       msg.push('<?php echo JText::_('COM_JOOMGALLERY_IMGMAN_ALERT_SELECT_THUMBNAIL_FILENAME', true); ?>');
     }
     alert(msg.join('\n'));

--- a/administrator/components/com_joomgallery/views/image/view.html.php
+++ b/administrator/components/com_joomgallery/views/image/view.html.php
@@ -30,62 +30,62 @@ class JoomGalleryViewImage extends JoomGalleryView
    */
   public function display($tpl = null)
   {
-    $item   = $this->get('Data');
-    $isNew  = ($item->id < 1);
+    $this->item   = $this->get('Data');
+    $this->isNew  = ($this->item->id < 1);
     $rating = 0.0;
 
     // Get the form and fill the fields
-    $form = $this->get('Form');
+    $this->form = $this->get('Form');
 
-    if($isNew)
+    if($this->isNew)
     {
       // Set some field attributes for javascript validation
-      $form->setFieldAttribute('detail_catid', 'required', true);
-      $form->setFieldAttribute('detail_catid', 'validate', 'joompositivenumeric');
-      $form->setFieldAttribute('thumb_catid',  'required', true);
-      $form->setFieldAttribute('thumb_catid',  'validate', 'joompositivenumeric');
-      $form->setFieldAttribute('imgfilename',  'required', true);
-      $form->setFieldAttribute('imgthumbname', 'required', true);
+      $this->form->setFieldAttribute('detail_catid', 'required', true);
+      $this->form->setFieldAttribute('detail_catid', 'validate', 'joompositivenumeric');
+      $this->form->setFieldAttribute('thumb_catid',  'required', true);
+      $this->form->setFieldAttribute('thumb_catid',  'validate', 'joompositivenumeric');
+      $this->form->setFieldAttribute('imgfilename',  'required', true);
+      $this->form->setFieldAttribute('imgthumbname', 'required', true);
 
       // Detail images
-      $detail_catpath     = JoomHelper::getCatPath($item->detail_catid);
+      $detail_catpath     = JoomHelper::getCatPath($this->item->detail_catid);
       $detail_path        = $this->_ambit->get('img_path').$detail_catpath;
-      $form->setFieldAttribute('imgfilename', 'directory', $detail_path);
-      $imgfilename_field  = $this->_findFieldByFieldName($form, 'imgfilename');
-      $imagelib_field     = $this->_findFieldByFieldName($form, 'imagelib2');
+      $this->form->setFieldAttribute('imgfilename', 'directory', $detail_path);
+      $imgfilename_field  = $this->_findFieldByFieldName($this->form, 'imgfilename');
+      $imagelib_field     = $this->_findFieldByFieldName($this->form, 'imagelib2');
 
       // Thumbnail images
-      $thumb_catpath       = JoomHelper::getCatPath($item->thumb_catid);
+      $thumb_catpath       = JoomHelper::getCatPath($this->item->thumb_catid);
       $thumb_path          = $this->_ambit->get('thumb_path').$thumb_catpath;
-      $form->setFieldAttribute('imgthumbname', 'directory', $thumb_path);
-      $imgthumbname_field  = $this->_findFieldByFieldName($form, 'imgthumbname');
-      $imagelib_field      = $this->_findFieldByFieldName($form, 'imagelib');
+      $this->form->setFieldAttribute('imgthumbname', 'directory', $thumb_path);
+      $imgthumbname_field  = $this->_findFieldByFieldName($this->form, 'imgthumbname');
+      $imagelib_field      = $this->_findFieldByFieldName($this->form, 'imagelib');
     }
     else
     {
-      if($item->imgvotes > 0)
+      if($this->item->imgvotes > 0)
       {
-        $rating = JoomHelper::getRating($item->id);
+        $rating = JoomHelper::getRating($this->item->id);
       }
     }
 
     // Set maximum allowed user count to switch from listbox to modal popup selection
-    $form->setFieldAttribute('owner', 'useListboxMaxUserCount', $this->_config->get('jg_use_listbox_max_user_count'));
+    $this->form->setFieldAttribute('owner', 'useListboxMaxUserCount', $this->_config->get('jg_use_listbox_max_user_count'));
 
     // Bind the data to the form
-    $form->bind($item);
+    $this->form->bind($this->item);
 
     // Set some form fields manually
-    if($isNew)
+    if($this->isNew)
     {
       // Does the original image file exist
-      if($form->getValue('imgfilename', null) == '')
+      if($this->form->getValue('imgfilename', null) == '')
       {
-        $form->setValue('original_exists', null, JText::_('COM_JOOMGALLERY_IMGMAN_NO_IMAGE_SELECTED'));
+        $this->form->setValue('original_exists', null, JText::_('COM_JOOMGALLERY_IMGMAN_NO_IMAGE_SELECTED'));
       }
       else
       {
-        if(JFile::exists($this->_ambit->getImg('orig_path', $item->imgfilename, null, $item->detail_catid)))
+        if(JFile::exists($this->_ambit->getImg('orig_path', $this->item->imgfilename, null, $this->item->detail_catid)))
         {
           $orig_msg = JText::_('COM_JOOMGALLERY_IMGMAN_ORIGINAL_EXIST');
           $color = 'green';
@@ -95,8 +95,8 @@ class JoomGalleryViewImage extends JoomGalleryView
           $orig_msg = JText::_('COM_JOOMGALLERY_IMGMAN_ORIGINAL_NOT_EXIST');
           $color = 'red';
         }
-        $form->setValue('original_exists', null, $orig_msg);
-        $original_exists_field = $this->_findFieldByFieldName($form, 'original_exists');
+        $this->form->setValue('original_exists', null, $orig_msg);
+        $original_exists_field = $this->_findFieldByFieldName($this->form, 'original_exists');
         $js = "
         window.addEvent('domready', function() {
           $('".$original_exists_field->id."').setStyle('color', '".$color."');
@@ -107,67 +107,64 @@ class JoomGalleryViewImage extends JoomGalleryView
     else
     {
       // Plublished and hidden state
-      if($item->published)
+      if($this->item->published)
       {
-        $form->setValue('publishhiddenstate', null, $item->hidden ? JText::_('COM_JOOMGALLERY_COMMON_PUBLISHED_BUT_HIDDEN') : JText::_('COM_JOOMGALLERY_COMMON_STATE_PUBLISHED') );
+        $this->form->setValue('publishhiddenstate', null, $this->item->hidden ? JText::_('COM_JOOMGALLERY_COMMON_PUBLISHED_BUT_HIDDEN') : JText::_('COM_JOOMGALLERY_COMMON_STATE_PUBLISHED') );
       }
       else
       {
-        $form->setValue('publishhiddenstate', null, JText::_('COM_JOOMGALLERY_COMMON_STATE_UNPUBLISHED'));
+        $this->form->setValue('publishhiddenstate', null, JText::_('COM_JOOMGALLERY_COMMON_STATE_UNPUBLISHED'));
       }
       // Rating
-      $form->setValue('rating', null, JText::sprintf('COM_JOOMGALLERY_IMGMAN_IMAGE_VOTES', $rating, $item->imgvotes));
+      $this->form->setValue('rating', null, JText::sprintf('COM_JOOMGALLERY_IMGMAN_IMAGE_VOTES', $rating, $this->item->imgvotes));
       // Date
-      $form->setValue('date', null, JHTML::_('date',  $item->imgdate,  JText::_('DATE_FORMAT_LC2')));
+      $this->form->setValue('date', null, JHTML::_('date',  $this->item->imgdate,  JText::_('DATE_FORMAT_LC2')));
     }
 
     // Set image source for detail image preview
-    if($item->imgfilename)
+    if($this->item->imgfilename)
     {
-      if($isNew)
+      if($this->isNew)
       {
         // We have to look for the image ID fist because the image may have to be output through the script
-        $id = $this->getModel()->getIdByFilename($item->imgfilename, $item->detail_catid);
+        $id = $this->getModel()->getIdByFilename($this->item->imgfilename, $this->item->detail_catid);
         $imgsource = $this->_ambit->getImg('img_url', $id);
       }
       else
       {
-        $imgsource = $this->_ambit->getImg('img_url', $item);
+        $imgsource = $this->_ambit->getImg('img_url', $this->item);
       }
     }
     else
     {
       $imgsource = '../media/system/images/blank.png';
     }
-    $form->setValue('imagelib2', null, $imgsource);
+    $this->form->setValue('imagelib2', null, $imgsource);
 
     // Set image source for thumbnail preview
-    if($item->imgthumbname)
+    if($this->item->imgthumbname)
     {
-      if($isNew)
+      if($this->isNew)
       {
         // We have to look for the image ID fist because the image may have to be output through the script
-        $id = $this->getModel()->getIdByFilename($item->imgthumbname, $item->thumb_catid, true);
+        $id = $this->getModel()->getIdByFilename($this->item->imgthumbname, $this->item->thumb_catid, true);
         $thumbsource = $this->_ambit->getImg('thumb_url', $id);
       }
       else
       {
-        $thumbsource = $this->_ambit->getImg('thumb_url', $item);
+        $thumbsource = $this->_ambit->getImg('thumb_url', $this->item);
       }
     }
     else
     {
       $thumbsource = '../media/system/images/blank.png';
     }
-    $form->setValue('imagelib', null, $thumbsource);
+    $this->form->setValue('imagelib', null, $thumbsource);
 
     JHtml::_('jquery.framework');
 
-    $this->assignRef('item',              $item);
-    $this->assignRef('isNew',             $isNew);
-    $this->assignRef('form',              $form);
-
     $this->addToolbar();
+
     parent::display($tpl);
   }
 

--- a/administrator/components/com_joomgallery/views/image/view.raw.php
+++ b/administrator/components/com_joomgallery/views/image/view.raw.php
@@ -32,7 +32,7 @@ class JoomGalleryViewImage extends JoomGalleryView
   {
     jimport('joomla.filesystem.file');
 
-    $type     = JRequest::getWord('type', 'thumb');
+    $type     = $this->_mainframe->input->getWord('type', 'thumb');
     $image    = $this->get('Data');
     $img      = $this->_ambit->getImg($type.'_path', $image);
 
@@ -54,7 +54,7 @@ class JoomGalleryViewImage extends JoomGalleryView
         $mime = 'image/png';
         break;
       default:
-        JError::raiseError(404, JText::sprintf('COM_JOOMGALLERY_COMMON_MSG_MIME_NOT_ALLOWED', $info[2]));
+        throw new Exception(JText::sprintf('COM_JOOMGALLERY_COMMON_MSG_MIME_NOT_ALLOWED', $info[2]));
         break;
     }
 
@@ -63,8 +63,8 @@ class JoomGalleryViewImage extends JoomGalleryView
 
     // Set header to specify the file name
     $disposition = 'inline';
-    JResponse::setHeader('Content-disposition', $disposition.'; filename='.basename($img));
+    $this->_mainframe->setHeader('Content-disposition', $disposition.'; filename='.basename($img));
 
-    echo JFile::read($img);
+    echo file_get_contents($img);
   }
 }

--- a/administrator/components/com_joomgallery/views/maintenance/view.html.php
+++ b/administrator/components/com_joomgallery/views/maintenance/view.html.php
@@ -37,7 +37,7 @@ class JoomGalleryViewMaintenance extends JoomGalleryView
       background-image:url(templates/khepri/images/toolbar/icon-32-refresh.png);
     }');
 
-    $lists = array();
+    $this->lists = array();
 
     jimport('joomla.html.pane');
     $tabs = array('images'      => 0,
@@ -56,106 +56,106 @@ class JoomGalleryViewMaintenance extends JoomGalleryView
       $tab = 'images';
     }
 
-    $checked = $this->_mainframe->getUserState('joom.maintenance.checked');
+    $this->checked = $this->_mainframe->getUserState('joom.maintenance.checked');
 
-    $state  = $this->get('State');
+    $this->state   = $this->get('State');
 
     switch($tab)
     {
       case 'categories':
         // Select list of the batch jobs for the categories
-        $b_options              = array();
-        $b_options[]            = JHTML::_('select.option', '',                   JText::_('COM_JOOMGALLERY_MAIMAN_SELECT_JOB'));
-        $b_options[]            = JHTML::_('select.option', 'setuser',            JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_SET_NEW_USER'));
-        $b_options[]            = JHTML::_('select.option', 'addorphanedfolders', JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_ADD_ORPHANED_FOLDERS'));
-        $b_options[]            = JHTML::_('select.option', 'create',             JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_CREATE_FOLDERS'));
-        $b_options[]            = JHTML::_('select.option', 'removecategory',     JText::_('COM_JOOMGALLERY_MAIMAN_CT_OPTION_REMOVE_CATEGORIES'));
-        $lists['cat_jobs']      = JHTML::_( 'select.genericlist', $b_options, 'job',
+        $b_options               = array();
+        $b_options[]             = JHTML::_('select.option', '',                   JText::_('COM_JOOMGALLERY_MAIMAN_SELECT_JOB'));
+        $b_options[]             = JHTML::_('select.option', 'setuser',            JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_SET_NEW_USER'));
+        $b_options[]             = JHTML::_('select.option', 'addorphanedfolders', JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_ADD_ORPHANED_FOLDERS'));
+        $b_options[]             = JHTML::_('select.option', 'create',             JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_CREATE_FOLDERS'));
+        $b_options[]             = JHTML::_('select.option', 'removecategory',     JText::_('COM_JOOMGALLERY_MAIMAN_CT_OPTION_REMOVE_CATEGORIES'));
+        $this->lists['cat_jobs'] = JHTML::_('select.genericlist', $b_options, 'job',
                                             'class="inputbox" size="1" onchange="joom_selectbatchjob(this.value);"',
                                             'value', 'text');
 
-        $f_options              = array();
-        $f_options[]            = JHTML::_('select.option', 0, JText::_('COM_JOOMGALLERY_COMMON_OPTION_ALL_CATEGORIES'));
-        $f_options[]            = JHTML::_('select.option', 1, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_MISSING_THUMB_FOLDER_ONLY'));
-        $f_options[]            = JHTML::_('select.option', 2, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_MISSING_IMG_FOLDER_ONLY'));
-        $f_options[]            = JHTML::_('select.option', 3, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_MISSING_ORIG_FOLDER_ONLY'));
-        $f_options[]            = JHTML::_('select.option', 4, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_MISSING_USER_ONLY'));
-        $f_options[]            = JHTML::_('select.option', 5, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_MISSING_PARENT_CATEGORY_ONLY'));
-        $lists['cat_filter']    = JHTML::_( 'select.genericlist', $f_options, 'filter_type',
-                                            'class="inputbox" size="1" onchange="document.adminForm.submit();"',
-                                            'value', 'text', $state->get('filter.type'));
+        $f_options                 = array();
+        $f_options[]               = JHTML::_('select.option', 0, JText::_('COM_JOOMGALLERY_COMMON_OPTION_ALL_CATEGORIES'));
+        $f_options[]               = JHTML::_('select.option', 1, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_MISSING_THUMB_FOLDER_ONLY'));
+        $f_options[]               = JHTML::_('select.option', 2, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_MISSING_IMG_FOLDER_ONLY'));
+        $f_options[]               = JHTML::_('select.option', 3, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_MISSING_ORIG_FOLDER_ONLY'));
+        $f_options[]               = JHTML::_('select.option', 4, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_MISSING_USER_ONLY'));
+        $f_options[]               = JHTML::_('select.option', 5, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_MISSING_PARENT_CATEGORY_ONLY'));
+        $this->lists['cat_filter'] = JHTML::_('select.genericlist', $f_options, 'filter_type',
+                                              'class="inputbox" size="1" onchange="document.adminForm.submit();"',
+                                              'value', 'text', $this->state->get('filter.type'));
 
-        if(!is_null($checked))
+        if(!is_null($this->checked))
         {
           // Get data from the model
-          $items  = $this->get('Categories');
+          $items = $this->get('Categories');
         }
         break;
       case 'orphans':
         // Select list of the batch jobs for the orphans
-        $b_options              = array();
-        $b_options[]            = JHTML::_('select.option', '',                 JText::_('COM_JOOMGALLERY_MAIMAN_SELECT_JOB'));
-        $b_options[]            = JHTML::_('select.option', 'addorphan',        JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_ADD_ORPHANS'));
-        $b_options[]            = JHTML::_('select.option', 'applysuggestions', JText::_('COM_JOOMGALLERY_MAIMAN_APPLY_SUGGESTIONS'));
-        $b_options[]            = JHTML::_('select.option', 'deleteorphan',     JText::_('COM_JOOMGALLERY_MAIMAN_REMOVE_ORPHANS'));
-        $lists['orphan_jobs']   = JHTML::_( 'select.genericlist', $b_options, 'job',
-                                            'class="inputbox" size="1"',
-                                            'value', 'text');
+        $b_options                  = array();
+        $b_options[]                = JHTML::_('select.option', '',                 JText::_('COM_JOOMGALLERY_MAIMAN_SELECT_JOB'));
+        $b_options[]                = JHTML::_('select.option', 'addorphan',        JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_ADD_ORPHANS'));
+        $b_options[]                = JHTML::_('select.option', 'applysuggestions', JText::_('COM_JOOMGALLERY_MAIMAN_APPLY_SUGGESTIONS'));
+        $b_options[]                = JHTML::_('select.option', 'deleteorphan',     JText::_('COM_JOOMGALLERY_MAIMAN_REMOVE_ORPHANS'));
+        $this->lists['orphan_jobs'] = JHTML::_('select.genericlist', $b_options, 'job',
+                                               'class="inputbox" size="1"',
+                                               'value', 'text');
 
-        $p_options                = array();
-        $p_options[]              = JHTML::_('select.option', 0, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_ALL_FILES'));
-        $p_options[]              = JHTML::_('select.option', 1, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_PROPOSAL_AVAILABLE'));
-        $p_options[]              = JHTML::_('select.option', 2, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_NO_PROPOSAL_AVAILABLE'));
-        $lists['orphan_proposal'] = JHTML::_( 'select.genericlist', $p_options, 'filter_proposal',
-                                              'class="inputbox" size="1" onchange="document.adminForm.submit();"',
-                                              'value', 'text', $state->get('filter.proposal'));
+        $p_options                      = array();
+        $p_options[]                    = JHTML::_('select.option', 0, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_ALL_FILES'));
+        $p_options[]                    = JHTML::_('select.option', 1, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_PROPOSAL_AVAILABLE'));
+        $p_options[]                    = JHTML::_('select.option', 2, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_NO_PROPOSAL_AVAILABLE'));
+        $this->lists['orphan_proposal'] = JHTML::_('select.genericlist', $p_options, 'filter_proposal',
+                                                   'class="inputbox" size="1" onchange="document.adminForm.submit();"',
+                                                   'value', 'text', $this->state->get('filter.proposal'));
 
-        $f_options                = array();
-        $f_options[]              = JHTML::_('select.option', 0, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_ALL_FILES'));
-        $f_options[]              = JHTML::_('select.option', 1, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_TYPE_THUMB_ONLY'));
-        $f_options[]              = JHTML::_('select.option', 2, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_TYPE_IMG_ONLY'));
-        $f_options[]              = JHTML::_('select.option', 3, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_TYPE_ORIG_ONLY'));
-        $f_options[]              = JHTML::_('select.option', 4, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_TYPE_UNKNOWN_ONLY'));
-        $lists['orphan_filter']   = JHTML::_( 'select.genericlist', $f_options, 'filter_type',
-                                              'class="inputbox" size="1" onchange="document.adminForm.submit();"',
-                                              'value', 'text', $state->get('filter.type'));
+        $f_options                    = array();
+        $f_options[]                  = JHTML::_('select.option', 0, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_ALL_FILES'));
+        $f_options[]                  = JHTML::_('select.option', 1, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_TYPE_THUMB_ONLY'));
+        $f_options[]                  = JHTML::_('select.option', 2, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_TYPE_IMG_ONLY'));
+        $f_options[]                  = JHTML::_('select.option', 3, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_TYPE_ORIG_ONLY'));
+        $f_options[]                  = JHTML::_('select.option', 4, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_TYPE_UNKNOWN_ONLY'));
+        $this->lists['orphan_filter'] = JHTML::_('select.genericlist', $f_options, 'filter_type',
+                                                 'class="inputbox" size="1" onchange="document.adminForm.submit();"',
+                                                 'value', 'text', $this->state->get('filter.type'));
 
-        if(!is_null($checked))
+        if(!is_null($this->checked))
         {
           // Get data from the model
-          $items  = $this->get('Orphans');
+          $items = $this->get('Orphans');
         }
         break;
       case 'folders':
         // Select list of the batch jobs for the orphans
-        $b_options              = array();
-        $b_options[]            = JHTML::_('select.option', '',                         JText::_('COM_JOOMGALLERY_MAIMAN_SELECT_JOB'));
-        $b_options[]            = JHTML::_('select.option', 'addorphanedfolder',        JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_ADD_ORPHANED_FOLDERS'));
-        $b_options[]            = JHTML::_('select.option', 'applyfoldersuggestions',   JText::_('COM_JOOMGALLERY_MAIMAN_APPLY_SUGGESTIONS'));
-        $b_options[]            = JHTML::_('select.option', 'deleteorphanedfolder',     JText::_('COM_JOOMGALLERY_MAIMAN_OF_OPTION_REMOVE_ORPHANED_FOLDERS'));
-        $lists['folder_jobs']   = JHTML::_( 'select.genericlist', $b_options, 'job',
-                                            'class="inputbox" size="1"',
-                                            'value', 'text');
+        $b_options                  = array();
+        $b_options[]                = JHTML::_('select.option', '',                         JText::_('COM_JOOMGALLERY_MAIMAN_SELECT_JOB'));
+        $b_options[]                = JHTML::_('select.option', 'addorphanedfolder',        JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_ADD_ORPHANED_FOLDERS'));
+        $b_options[]                = JHTML::_('select.option', 'applyfoldersuggestions',   JText::_('COM_JOOMGALLERY_MAIMAN_APPLY_SUGGESTIONS'));
+        $b_options[]                = JHTML::_('select.option', 'deleteorphanedfolder',     JText::_('COM_JOOMGALLERY_MAIMAN_OF_OPTION_REMOVE_ORPHANED_FOLDERS'));
+        $this->lists['folder_jobs'] = JHTML::_('select.genericlist', $b_options, 'job',
+                                               'class="inputbox" size="1"',
+                                               'value', 'text');
 
-        $p_options                = array();
-        $p_options[]              = JHTML::_('select.option', 0, JText::_('COM_JOOMGALLERY_MAIMAN_OF_OPTION_ALL_FOLDERS'));
-        $p_options[]              = JHTML::_('select.option', 1, JText::_('COM_JOOMGALLERY_MAIMAN_OF_OPTION_PROPOSAL_AVAILABLE_FOLDERS'));
-        $p_options[]              = JHTML::_('select.option', 2, JText::_('COM_JOOMGALLERY_MAIMAN_OF_OPTION_NO_PROPOSAL_AVAILABLE_FOLDERS'));
-        $lists['folder_proposal'] = JHTML::_( 'select.genericlist', $p_options, 'filter_proposal',
-                                              'class="inputbox" size="1" onchange="document.adminForm.submit();"',
-                                              'value', 'text', $state->get('filter.proposal'));
+        $p_options                      = array();
+        $p_options[]                    = JHTML::_('select.option', 0, JText::_('COM_JOOMGALLERY_MAIMAN_OF_OPTION_ALL_FOLDERS'));
+        $p_options[]                    = JHTML::_('select.option', 1, JText::_('COM_JOOMGALLERY_MAIMAN_OF_OPTION_PROPOSAL_AVAILABLE_FOLDERS'));
+        $p_options[]                    = JHTML::_('select.option', 2, JText::_('COM_JOOMGALLERY_MAIMAN_OF_OPTION_NO_PROPOSAL_AVAILABLE_FOLDERS'));
+        $this->lists['folder_proposal'] = JHTML::_('select.genericlist', $p_options, 'filter_proposal',
+                                                   'class="inputbox" size="1" onchange="document.adminForm.submit();"',
+                                                   'value', 'text', $this->state->get('filter.proposal'));
 
-        $f_options                = array();
-        $f_options[]              = JHTML::_('select.option', 0, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_ALL_FILES'));
-        $f_options[]              = JHTML::_('select.option', 1, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_TYPE_THUMB_ONLY'));
-        $f_options[]              = JHTML::_('select.option', 2, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_TYPE_IMG_ONLY'));
-        $f_options[]              = JHTML::_('select.option', 3, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_TYPE_ORIG_ONLY'));
-        $f_options[]              = JHTML::_('select.option', 4, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_TYPE_UNKNOWN_ONLY'));
-        $lists['folder_filter']   = JHTML::_( 'select.genericlist', $f_options, 'filter_type',
-                                              'class="inputbox" size="1" onchange="document.adminForm.submit();"',
-                                              'value', 'text', $state->get('filter.type'));
+        $f_options                    = array();
+        $f_options[]                  = JHTML::_('select.option', 0, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_ALL_FILES'));
+        $f_options[]                  = JHTML::_('select.option', 1, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_TYPE_THUMB_ONLY'));
+        $f_options[]                  = JHTML::_('select.option', 2, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_TYPE_IMG_ONLY'));
+        $f_options[]                  = JHTML::_('select.option', 3, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_TYPE_ORIG_ONLY'));
+        $f_options[]                  = JHTML::_('select.option', 4, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_TYPE_UNKNOWN_ONLY'));
+        $this->lists['folder_filter'] = JHTML::_('select.genericlist', $f_options, 'filter_type',
+                                                 'class="inputbox" size="1" onchange="document.adminForm.submit();"',
+                                                 'value', 'text', $this->state->get('filter.type'));
 
-        if(!is_null($checked))
+        if(!is_null($this->checked))
         {
           // Get data from the model
           $items = $this->get('OrphanedFolders');
@@ -163,28 +163,28 @@ class JoomGalleryViewMaintenance extends JoomGalleryView
         break;
       default:
         // Select list of the batch jobs for the images
-        $b_options              = array();
-        $b_options[]            = JHTML::_('select.option', '',           JText::_('COM_JOOMGALLERY_MAIMAN_SELECT_JOB'));
-        $b_options[]            = JHTML::_('select.option', 'setuser',    JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_SET_NEW_USER'));
-        $b_options[]            = JHTML::_('select.option', 'addorphans', JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_ADD_ORPHANS'));
-        $b_options[]            = JHTML::_('select.option', 'recreate',   JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_RECREATE'));
-        $b_options[]            = JHTML::_('select.option', 'remove',     JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_REMOVE_IMAGES'));
-        $lists['img_jobs']    = JHTML::_( 'select.genericlist', $b_options, 'job',
+        $b_options               = array();
+        $b_options[]             = JHTML::_('select.option', '',           JText::_('COM_JOOMGALLERY_MAIMAN_SELECT_JOB'));
+        $b_options[]             = JHTML::_('select.option', 'setuser',    JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_SET_NEW_USER'));
+        $b_options[]             = JHTML::_('select.option', 'addorphans', JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_ADD_ORPHANS'));
+        $b_options[]             = JHTML::_('select.option', 'recreate',   JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_RECREATE'));
+        $b_options[]             = JHTML::_('select.option', 'remove',     JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_REMOVE_IMAGES'));
+        $this->lists['img_jobs'] = JHTML::_('select.genericlist', $b_options, 'job',
                                             'class="inputbox" size="1" onchange="joom_selectbatchjob(this.value);"',
                                             'value', 'text');
 
-        $f_options              = array();
-        $f_options[]            = JHTML::_('select.option', 0, JText::_('COM_JOOMGALLERY_COMMON_OPTION_ALL_IMAGES'));
-        $f_options[]            = JHTML::_('select.option', 1, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_MISSING_THUMB_ONLY'));
-        $f_options[]            = JHTML::_('select.option', 2, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_MISSING_IMG_ONLY'));
-        $f_options[]            = JHTML::_('select.option', 3, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_MISSING_ORIG_ONLY'));
-        $f_options[]            = JHTML::_('select.option', 4, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_MISSING_USER_ONLY'));
-        $f_options[]            = JHTML::_('select.option', 5, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_MISSING_CATEGORY_ONLY'));
-        $lists['img_filter']    = JHTML::_( 'select.genericlist', $f_options, 'filter_type',
-                                            'class="inputbox" size="1" onchange="document.adminForm.submit();"',
-                                            'value', 'text', $state->get('filter.type'));
+        $f_options                 = array();
+        $f_options[]               = JHTML::_('select.option', 0, JText::_('COM_JOOMGALLERY_COMMON_OPTION_ALL_IMAGES'));
+        $f_options[]               = JHTML::_('select.option', 1, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_MISSING_THUMB_ONLY'));
+        $f_options[]               = JHTML::_('select.option', 2, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_MISSING_IMG_ONLY'));
+        $f_options[]               = JHTML::_('select.option', 3, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_MISSING_ORIG_ONLY'));
+        $f_options[]               = JHTML::_('select.option', 4, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_MISSING_USER_ONLY'));
+        $f_options[]               = JHTML::_('select.option', 5, JText::_('COM_JOOMGALLERY_MAIMAN_OPTION_MISSING_CATEGORY_ONLY'));
+        $this->lists['img_filter'] = JHTML::_('select.genericlist', $f_options, 'filter_type',
+                                              'class="inputbox" size="1" onchange="document.adminForm.submit();"',
+                                              'value', 'text', $this->state->get('filter.type'));
 
-        if(!is_null($checked))
+        if(!is_null($this->checked))
         {
           // Get data from the model
           $items = $this->get('Images');
@@ -192,37 +192,33 @@ class JoomGalleryViewMaintenance extends JoomGalleryView
         break;
     }
 
-    if(!is_null($checked))
+    if(!is_null($this->checked))
     {
       $this->items = $items;
       $this->pagination = $this->get('Pagination');
 
-      if($state->get('filter.inuse') && !$this->get('Total'))
+      if($this->state->get('filter.inuse') && !$this->get('Total'))
       {
         $this->_mainframe->enqueueMessage(JText::_('COM_JOOMGALLERY_MAIMAN_MSG_NO_ITEMS_FOUND_MATCHING_YOUR_QUERY'));
       }
     }
 
-    $information = $this->get('Information');
+    $this->information = $this->get('Information');
     $warning  = '<img src="'.$this->_ambit->getIcon('error.png').'" border="0" alt="Warning" height="11" width="11" />';
-    foreach($information as $key => $found)
+    foreach($this->information as $key => $found)
     {
       if($found)
       {
-        $information[$key] = '&nbsp;'.$warning;
+        $this->information[$key] = '&nbsp;'.$warning;
       }
       else
       {
-        $information[$key] = '';
+        $this->information[$key] = '';
       }
     }
 
-    $this->assignRef('current_tab',   $tab);
-    $this->assignRef('startOffset',   $tabs[$tab]);
-    $this->assignRef('checked',       $checked);
-    $this->assignRef('information',   $information);
-    $this->assignRef('lists',         $lists);
-    $this->assignRef('state',         $state);
+    $this->current_tab = $tab;
+    $this->startOffset = $tabs[$tab];
 
     $this->_doc->addScript($this->_ambit->getScript('maintenance.js'));
 

--- a/administrator/components/com_joomgallery/views/mini/tmpl/default_images.php
+++ b/administrator/components/com_joomgallery/views/mini/tmpl/default_images.php
@@ -82,7 +82,7 @@
 <?php endif; ?>
   </script>
   <div class="center">
-    <form action="index.php?option=<?php echo _JOOM_OPTION; ?>&amp;view=mini&amp;tmpl=component&amp;e_name=<?php echo $this->e_name; ?>&amp;object=<?php echo JRequest::getVar('object'); ?>" name="adminForm" method="post" onsubmit="javascript:ajaxRequest('<?php echo 'index.php?option='._JOOM_OPTION.'&view=mini&format=json'; ?>', 1, 'search=' + this.search.value); return false;">
+    <form action="index.php?option=<?php echo _JOOM_OPTION; ?>&amp;view=mini&amp;tmpl=component&amp;e_name=<?php echo $this->e_name; ?>&amp;object=<?php echo $this->_mainframe->input->get('object'); ?>" name="adminForm" method="post" onsubmit="javascript:ajaxRequest('<?php echo 'index.php?option='._JOOM_OPTION.'&view=mini&format=json'; ?>', 1, 'search=' + this.search.value); return false;">
       <div id="jg_bu_pagelinks" class="pageslinks">
         <?php echo $this->loadTemplate('pagination'); ?>
       </div>

--- a/administrator/components/com_joomgallery/views/mini/view.json.php
+++ b/administrator/components/com_joomgallery/views/mini/view.json.php
@@ -31,64 +31,63 @@ class JoomGalleryViewMini extends JoomGalleryView
    */
   function display($tpl = null)
   {
-    $e_name = $this->_mainframe->getUserStateFromRequest('joom.mini.e_name', 'e_name', 'text', 'string');
+    $this->e_name = $this->_mainframe->getUserStateFromRequest('joom.mini.e_name', 'e_name', 'text', 'string');
 
-    $catid = $this->_mainframe->getUserStateFromRequest('joom.mini.catid', 'catid', 0, 'int');
-    $this->assignRef('catid', $catid);
+    $this->catid  = $this->_mainframe->getUserStateFromRequest('joom.mini.catid', 'catid', 0, 'int');
     $this->prefix = $this->_mainframe->getUserStateFromRequest('joom.mini.prefix', 'prefix', 'joom', 'cmd');
 
     // Pagination
-    $total    = $this->get('TotalImages');
+    $this->total = $this->get('TotalImages');
 
     // Calculation of the number of total pages
-    $limit    = $this->_mainframe->getUserStateFromRequest('joom.mini.limit', 'limit', 30, 'int');
+    $limit = $this->_mainframe->getUserStateFromRequest('joom.mini.limit', 'limit', 30, 'int');
     if(!$limit)
     {
-      $totalpages = 1;
+      $this->totalpages = 1;
     }
     else
     {
-      $totalpages = floor($total / $limit);
-      $offcut     = $total % $limit;
+      $this->totalpages = floor($this->total / $limit);
+      $offcut     = $this->total % $limit;
       if($offcut > 0)
       {
-        $totalpages++;
+        $this->totalpages++;
       }
     }
 
-    $totalimages = $total;
-    $total = number_format($total, 0, ',', '.');
+    $totalimages = $this->total;
+    $this->total = number_format($this->total, 0, ',', '.');
 
     // Get the current page
-    $page = JRequest::getInt('page', 0);
-    if($page > $totalpages)
+    $this->page = $this->_mainframe->input->getInt('page', 0);
+    if($this->page > $this->totalpages)
     {
-      $page = $totalpages;
+      $this->page = $this->totalpages;
     }
-    if($page < 1)
+    if($this->page < 1)
     {
-      $page = 1;
+      $this->page = 1;
     }
 
     // Limitstart
-    $limitstart = ($page - 1) * $limit;
-    JRequest::setVar('limitstart', $limitstart);
+    $limitstart = ($this->page - 1) * $limit;
+    $this->_mainframe->input->set('limitstart', $limitstart);
 
-    if($total <= $limit)
+    if($this->total <= $limit)
     {
       $limitstart = 0;
-      JRequest::setVar('limitstart', $limitstart);
+      $this->_mainframe->input->set('limitstart', $limitstart);
     }
 
-    JRequest::setVar('limit', $limit);
+    $this->_mainframe->input->set('limit', $limit);
 
     require_once JPATH_COMPONENT_ADMINISTRATOR.'/helpers/pagination.php';
     $onclick = 'javascript:ajaxRequest(\'index.php?option='._JOOM_OPTION.'&view=mini&format=json\', %u); return false;';
     $this->pagination = new JoomPagination($totalimages, $limitstart, $limit, '', null, $onclick);
 
-    $images = $this->get('Images');
+    $this->images = $this->get('Images');
 
-    foreach($images as $key => $image)
+    foreach($this->images as $key => $image)
     {
       $image->thumb_src = null;
       $thumb = $this->_ambit->getImg('thumb_path', $image);
@@ -103,17 +102,10 @@ class JoomGalleryViewMini extends JoomGalleryView
         $image->overlib       = str_replace(array("\r\n", "\r", "\n"), '', htmlspecialchars($overlib, ENT_QUOTES, 'UTF-8'));
       }
 
-      $images[$key]           = $image;
+      $this->images[$key]           = $image;
     }
 
-    $object = $this->_mainframe->getUserStateFromRequest('joom.mini.object', 'object', '', 'cmd');
-
-    $this->assignRef('images',      $images);
-    $this->assignRef('total',       $total);
-    $this->assignRef('totalpages',  $totalpages);
-    $this->assignRef('page',        $page);
-    $this->assignRef('object',      $object);
-    $this->assignRef('e_name',      $e_name);
+    $this->object = $this->_mainframe->getUserStateFromRequest('joom.mini.object', 'object', '', 'cmd');
 
     $output = array();
     $output['minis']      = $this->loadTemplate('minis');

--- a/administrator/components/com_joomgallery/views/mini/view.raw.php
+++ b/administrator/components/com_joomgallery/views/mini/view.raw.php
@@ -110,7 +110,7 @@ class JoomGalleryViewMini extends JoomGalleryView
       $this->total = number_format($this->total, 0, JText::_('COM_JOOMGALLERY_COMMON_DECIMAL_SEPARATOR'), JText::_('COM_JOOMGALLERY_COMMON_THOUSANDS_SEPARATOR'));
 
       // Get the current page
-      $this->page = JRequest::getInt('page', 0);
+      $this->page = $this->_mainframe->input->getInt('page', 0);
       if($this->page > $this->totalpages)
       {
         $this->page = $this->totalpages;
@@ -122,15 +122,15 @@ class JoomGalleryViewMini extends JoomGalleryView
 
       // Limitstart
       $limitstart = ($this->page - 1) * $limit;
-      JRequest::setVar('limitstart', $limitstart);
+      $this->_mainframe->input->set('limitstart', $limitstart);
 
       if($this->total <= $limit)
       {
         $limitstart = 0;
-        JRequest::setVar('limitstart', $limitstart);
+        $this->_mainframe->input->set('limitstart', $limitstart);
       }
 
-      JRequest::setVar('limit', $limit);
+      $this->_mainframe->input->set('limit', $limit);
 
       require_once JPATH_COMPONENT_ADMINISTRATOR.'/helpers/pagination.php';
       $onclick = 'javascript:ajaxRequest(\'index.php?option='._JOOM_OPTION.'&view=mini&format=json\', %u); return false;';

--- a/administrator/components/com_joomgallery/views/move/view.html.php
+++ b/administrator/components/com_joomgallery/views/move/view.html.php
@@ -37,12 +37,9 @@ class JoomGalleryViewMove extends JoomGalleryView
     JToolbarHelper::spacer();
 
     $catid = $this->_mainframe->getUserStateFromRequest('joom.move.catid', 'catid', 0, 'int');
-    $items = $this->get('Images');
-    $lists = array();
-    $lists['cats'] = JHTML::_('joomselect.categorylist', $catid, 'catid', 'class="inputbox" size="1" ', null, '- ', null, 'joom.upload');
-
-    $this->assignRef('items', $items);
-    $this->assignRef('lists', $lists);
+    $this->items = $this->get('Images');
+    $this->lists = array();
+    $this->lists['cats'] = JHTML::_('joomselect.categorylist', $catid, 'catid', 'class="inputbox" size="1" ', null, '- ', null, 'joom.upload');
 
     parent::display($tpl);
   }

--- a/administrator/components/com_joomgallery/views/upload/tmpl/default.php
+++ b/administrator/components/com_joomgallery/views/upload/tmpl/default.php
@@ -1,7 +1,7 @@
 <?php defined('_JEXEC') or die('Direct Access to this location is not allowed.');
 JHtml::_('behavior.formvalidation');
 JHtml::_('bootstrap.tooltip'); ?>
-<form action="index.php" method="post" name="adminForm" id="upload-form" enctype="multipart/form-data" class="form-validate form-horizontal" onsubmit="if(this.task.value == 'upload' && !document.formvalidator.isValid(document.id('upload-form'))){alert('<?php echo JText::_('JGLOBAL_VALIDATION_FORM_FAILED', true); ?>');return false;} return joomOnSubmit();">
+<form action="index.php" method="post" name="adminForm" id="upload-form" enctype="multipart/form-data" class="form-validate form-horizontal" onsubmit="if(document.getElementsByName('task')[0].value == 'upload' && !document.formvalidator.isValid(document.id('upload-form'))){alert('<?php echo JText::_('JGLOBAL_VALIDATION_FORM_FAILED', true); ?>');return false;} return joomOnSubmit();">
 <?php if(!empty($this->sidebar)): ?>
   <div id="j-sidebar-container" class="span2">
     <?php echo $this->sidebar; ?>

--- a/components/com_joomgallery/controller.php
+++ b/components/com_joomgallery/controller.php
@@ -13,8 +13,6 @@
 
 defined('_JEXEC') or die('Direct Access to this location is not allowed.');
 
-jimport('joomla.application.component.controller');
-
 /**
  * JoomGallery Component Controller
  *
@@ -70,9 +68,6 @@ class JoomGalleryController extends JControllerLegacy
 
     $this->_ambit     = JoomAmbit::getInstance();
     $this->_config    = JoomConfig::getInstance();
-
-    /*$this->_mainframe = JFactory::getApplication('site');
-    $this->_user      = JFactory::getUser();*/
   }
 
   /**
@@ -86,15 +81,15 @@ class JoomGalleryController extends JControllerLegacy
   public function display($cachable = false, $urlparams = false)
   {
     // Set a default view if none exists
-    if(!$view = JRequest::getCmd('view'))
+    if(!$view = $this->input->getCmd('view'))
     {
-      JRequest::setVar('view', 'gallery');
+      $this->input->set('view', 'gallery');
     }
 
     // Increase hit counter in detail view if image view isn't used
     if($view == 'detail' && $this->_config->get('jg_use_real_paths'))
     {
-      $this->getModel('image')->hit(JRequest::getInt('id'));
+      $this->getModel('image')->hit($this->input->getInt('id'));
     }
 
     parent::display($cachable, $urlparams);
@@ -144,7 +139,7 @@ class JoomGalleryController extends JControllerLegacy
                   ->where('zipname = '.$this->_db->q($row->zipname));
             $this->_db->setQuery($query);
           }
-          $this->_db->query();
+          $this->_db->execute();
         }
       }
     }
@@ -171,6 +166,6 @@ class JoomGalleryController extends JControllerLegacy
 
     $type = $this->_config->get('jg_downloadfile') ? 'orig' : 'img';
 
-    $this->setRedirect(JRoute::_('index.php?view=image&format=raw&id='.JRequest::getInt('id').'&download=1&type='.$type, false));
+    $this->setRedirect(JRoute::_('index.php?view=image&format=raw&id='.$this->input->getInt('id').'&download=1&type='.$type, false));
   }
 }

--- a/components/com_joomgallery/controllers/ajaxupload.raw.php
+++ b/components/com_joomgallery/controllers/ajaxupload.raw.php
@@ -35,7 +35,7 @@ class JoomGalleryControllerAjaxupload extends JControllerLegacy
 
     $uploader = new JoomUpload();
 
-    if($image = $uploader->upload(JRequest::getCmd('type', 'ajax')))
+    if($image = $uploader->upload($this->input->getCmd('type', 'ajax')))
     {
       $result['success'] = true;
       if(is_object($image))

--- a/components/com_joomgallery/controllers/categories.json.php
+++ b/components/com_joomgallery/controllers/categories.json.php
@@ -33,11 +33,11 @@ class JoomGalleryControllerCategories extends JControllerLegacy
 
     $model = $this->getModel('categories');
 
-    $action     = JRequest::getCmd('action');
-    $filter     = JRequest::getInt('filter');
-    $search     = JRequest::getString('searchstring');
-    $limitstart = JRequest::getInt('more');
-    $current    = JRequest::getInt('current');
+    $action     = $this->input->getCmd('action');
+    $filter     = $this->input->getInt('filter');
+    $search     = $this->input->getString('searchstring');
+    $limitstart = $this->input->getInt('more');
+    $current    = $this->input->getInt('current');
 
     echo new JJsonResponse($model->getAllowedCategories($action, $filter, $search, $limitstart, $current));
   }
@@ -55,9 +55,9 @@ class JoomGalleryControllerCategories extends JControllerLegacy
     JSession::checkToken() or jexit(JText::_('JINVALID_TOKEN'));
 
     // Get the arrays from the request
-    $pks            = JRequest::getVar('cid',	null,	'post',	'array');
-    $order          = JRequest::getVar('order',	null, 'post', 'array');
-    $originalOrder  = explode(',', JRequest::getString('original_order_values'));
+    $pks            = $this->input->post->get('cid',	null, 'array');
+    $order          = $this->input->post->get('order',	null, 'array');
+    $originalOrder  = explode(',', $this->input->getString('original_order_values'));
 
     // Make sure something has changed
     if($order !== $originalOrder)
@@ -82,12 +82,11 @@ class JoomGalleryControllerCategories extends JControllerLegacy
   {
     require_once JPATH_ADMINISTRATOR.'/components/com_languages/helpers/jsonresponse.php';
 
-    $input = JFactory::getApplication()->input;
     $model = $this->getModel('category');
 
     try
     {
-      $model->unlock($input->getInt('catid'), $input->getString('password'));
+      $model->unlock($input->getInt('catid'), $this->input->getString('password'));
 
       echo new JJsonResponse();
     }

--- a/components/com_joomgallery/controllers/category.php
+++ b/components/com_joomgallery/controllers/category.php
@@ -33,16 +33,16 @@ class JoomGalleryControllerCategory extends JControllerLegacy
 
     // Get limitstart from request to set the correct limitstart (page) for redirect url
     $slimitstart = '';
-    if(JRequest::getVar('limitstart', null) != null)
+    if($this->input->get('limitstart', null) != null)
     {
-      $slimitstart = '&limitstart='.JRequest::getInt('limitstart', 0);
+      $slimitstart = '&limitstart='.$this->input->getInt('limitstart', 0);
     }
 
     // Set default redirect URL
     $redirect = 'index.php?view=usercategories'.$slimitstart;
 
     // Check whether a redirect is requested
-    if($url = JRequest::getVar('redirect', '', '', 'base64'))
+    if($url = $this->input->getBase64('redirect', ''))
     {
       $url = base64_decode($url);
       if(JURI::isInternal($url))
@@ -75,9 +75,9 @@ class JoomGalleryControllerCategory extends JControllerLegacy
 
     // Get limitstart from request to set the correct limitstart (page) for redirect url
     $slimitstart = '';
-    if(JRequest::getVar('limitstart', null) != null)
+    if($this->input->get('limitstart', null) != null)
     {
-      $slimitstart = '&limitstart='.JRequest::getInt('limitstart', 0);
+      $slimitstart = '&limitstart='.$this->input->getInt('limitstart', 0);
     }
 
     try
@@ -105,9 +105,9 @@ class JoomGalleryControllerCategory extends JControllerLegacy
 
     // Get limitstart from request to set the correct limitstart (page) for redirect url
     $slimitstart = '';
-    if(JRequest::getVar('limitstart', null) != null)
+    if($this->input->get('limitstart', null) != null)
     {
-      $slimitstart = '&limitstart='.JRequest::getInt('limitstart', 0);
+      $slimitstart = '&limitstart='.$this->input->getInt('limitstart', 0);
     }
 
     if($model->publish())
@@ -130,10 +130,9 @@ class JoomGalleryControllerCategory extends JControllerLegacy
    */
   public function unlock()
   {
-    $input = JFactory::getApplication()->input;
     $model = $this->getModel('category');
 
-    $catid = $input->getInt('catid');
+    $catid = $this->input->getInt('catid');
 
     try
     {

--- a/components/com_joomgallery/controllers/favourites.php
+++ b/components/com_joomgallery/controllers/favourites.php
@@ -32,12 +32,12 @@ class JoomGalleryControllerFavourites extends JControllerLegacy
     $model = $this->getModel('favourites');
 
     // Determine correct redirect URL
-    if($catid = JRequest::getInt('catid'))
+    if($catid = $this->input->getInt('catid'))
     {
       // Request was initiated from category view
       $url = JRoute::_('index.php?view=category&catid='.$catid, false);
     }
-    elseif(($toplist = JRequest::getVar('toplist')) !== null)
+    elseif(($toplist = $this->input->get('toplist')) !== null)
     {
       // Request was initiated from toplist view
       if(empty($toplist))
@@ -51,7 +51,7 @@ class JoomGalleryControllerFavourites extends JControllerLegacy
         $url = JRoute::_('index.php?view=toplist&type='.$toplist, false);
       }
     }
-    elseif(($sstring = JRequest::getVar('sstring')) !== null)
+    elseif(($sstring = $this->input->get('sstring')) !== null)
     {
      // Request was initiated from search view
       $url = JRoute::_('index.php?view=search&sstring='.$sstring, false);
@@ -82,18 +82,18 @@ class JoomGalleryControllerFavourites extends JControllerLegacy
    */
   public function addImages()
   {
-    $catid  = JRequest::getInt('catid');
+    $catid  = $this->input->getInt('catid');
     $model  = $this->getModel('favourites');
 
     // Determine correct redirect URL
-    if(JRequest::getCmd('return') == 'gallery')
+    if($this->input->getCmd('return') == 'gallery')
     {
       // Request was initiated from gallery view
       $url = JRoute::_('index.php?view=gallery', false);
     }
     else
     {
-      if($return = JRequest::getInt('return'))
+      if($return = $this->input->getInt('return'))
       {
         // Request was initiated from parent category view
         $url = JRoute::_('index.php?view=category&catid='.(int) $return, false);

--- a/components/com_joomgallery/controllers/image.php
+++ b/components/com_joomgallery/controllers/image.php
@@ -31,65 +31,21 @@ class JoomGalleryControllerImage extends JControllerLegacy
   {
     $model = $this->getModel('edit');
 
-    $array = JRequest::getVar('id',  0, '', 'array');
+    $array = $this->input->get('id', array(0), 'array');
 
     $model->setId((int)$array[0]);
 
-    /*$data = JRequest::get('post');
-
-    //editing more than one image?
-    if(isset($data['cids']))
-    {
-      //we need selected fields
-      if(!isset($data['change']))
-      {
-        $this->setRedirect($this->_ambit->getRedirectUrl(), JText::_('Please check the boxes of fields you want to change'), 'notice');
-        return;
-      }
-
-      $cids_string  = $data['cids'];
-      $cids         = explode(',', $cids_string);
-      $change       = $data['change'];
-
-      //delete all unselected fields
-      foreach($data as $key => $value)
-      {
-        if(!in_array($key, $change))
-        {
-          unset($data[$key]);
-        }
-      }
-
-      //save each image
-      $return = array();
-      foreach($cids as $cid)
-      {
-        $data['cid']  = $cid;
-        $return[]     = $model->store($data);
-      }
-
-      if(!in_array(false, $return))
-      {
-      $this->setRedirect($this->_ambit->getRedirectUrl(), JText::sprintf('Successfully saved %d images.', count($return)));
-      }
-      else
-      {
-        $this->setRedirect($this->_ambit->getRedirectUrl(), JText::sprintf('Error saving images.'), 'error');
-      }
-      return;
-    }*/
-
     // Get limitstart from request to set the correct limitstart (page) for redirect url
     $slimitstart = '';
-    if(JRequest::getVar('limitstart', null) != null)
+    if($this->input->get('limitstart', null) != null)
     {
-      $slimitstart = '&limitstart='.JRequest::getInt('limitstart', 0);
+      $slimitstart = '&limitstart='.$this->input->getInt('limitstart', 0);
     }
 
     // Set standard redirect URL
     $redirect = 'index.php?view=userpanel'.$slimitstart;
     // Is there any redirect requested?
-    $url = JRequest::getVar('redirect', null, 'default', 'base64');
+    $url = $this->input->getBase64('redirect', null);
     if($url !== null)
     {
       $url = base64_decode($url);
@@ -122,21 +78,21 @@ class JoomGalleryControllerImage extends JControllerLegacy
   {
     $model = $this->getModel('edit');
 
-    $array = JRequest::getVar('id',  0, '', 'array');
+    $array = $this->input->get('id', array(0), 'array');
 
     $model->setId((int)$array[0]);
 
     // Get limitstart from request to set the correct limitstart (page) for redirect url
     $slimitstart = '';
-    if(JRequest::getVar('limitstart', null) != null)
+    if($this->input->get('limitstart', null) != null)
     {
-      $slimitstart = '&limitstart='.JRequest::getInt('limitstart', 0);
+      $slimitstart = '&limitstart='.$this->input->get('limitstart', 0);
     }
 
     // Set standard redirect URL
     $redirect = 'index.php?view=userpanel'.$slimitstart;
     // Is there any redirect requested?
-    $url = JRequest::getVar('redirect', null, 'default', 'base64');
+    $url = $this->input->getBase64('redirect', null);
     if($url !== null)
     {
       $url = base64_decode($url);
@@ -169,15 +125,15 @@ class JoomGalleryControllerImage extends JControllerLegacy
   {
     $model = $this->getModel('edit');
 
-    $array = JRequest::getVar('id',  0, '', 'array');
+    $array = $this->input->get('id', array(0), 'array');
 
     $model->setId((int)$array[0]);
 
     // Get limitstart from request to set the correct limitstart (page) for redirect url
     $slimitstart = '';
-    if(JRequest::getVar('limitstart', null) != null)
+    if($this->input->get('limitstart', null) != null)
     {
-      $slimitstart = '&limitstart='.JRequest::getInt('limitstart', 0);
+      $slimitstart = '&limitstart='.$this->input->getInt('limitstart', 0);
     }
 
     if($model->publish())

--- a/components/com_joomgallery/controllers/images.json.php
+++ b/components/com_joomgallery/controllers/images.json.php
@@ -35,8 +35,8 @@ class JoomGalleryControllerImages extends JControllerLegacy
 
     $conditions = array();
 
-    $cid   = JRequest::getVar('cid', array(), 'post', 'array');
-    $order = JRequest::getVar('order', array(), 'post', 'array');
+    $cid   = $this->input->post->get('cid', array(), 'array');
+    $order = $this->input->post->get('order', array(), 'array');
     $user  = JFactory::getUser();
 
     $row = JTable::getInstance('joomgalleryimages', 'Table');

--- a/components/com_joomgallery/controllers/report.php
+++ b/components/com_joomgallery/controllers/report.php
@@ -34,10 +34,10 @@ class JoomGalleryControllerReport extends JControllerLegacy
     $model = $this->getModel('report');
 
     // Determine correct redirect URL
-    $id       = JRequest::getInt('id');
-    $catid    = JRequest::getInt('catid');
-    $toplist  = JRequest::getVar('toplist');
-    $sstring  = JRequest::getVar('sstring');
+    $id       = $this->input->getInt('id');
+    $catid    = $this->input->getInt('catid');
+    $toplist  = $this->input->get('toplist');
+    $sstring  = $this->input->get('sstring');
 
     $redirect_url = 'index.php?view=detail&id='.$id;
     if($catid)

--- a/components/com_joomgallery/controllers/send2friend.php
+++ b/components/com_joomgallery/controllers/send2friend.php
@@ -33,11 +33,11 @@ class JoomGalleryControllerSend2Friend extends JControllerLegacy
 
     if(!$model->send())
     {
-      $this->setRedirect(JRoute::_('index.php?view=detail&id='.JRequest::getInt('id'), false), $model->getError(), 'error');
+      $this->setRedirect(JRoute::_('index.php?view=detail&id='.$this->input->getInt('id'), false), $model->getError(), 'error');
     }
     else
     {
-      $this->setRedirect(JRoute::_('index.php?view=detail&id='.JRequest::getInt('id'), false), JText::_('COM_JOOMGALLERY_DETAIL_SENDTOFRIEND_MSG_MAIL_SENT'));
+      $this->setRedirect(JRoute::_('index.php?view=detail&id='.$this->input->getInt('id'), false), JText::_('COM_JOOMGALLERY_DETAIL_SENDTOFRIEND_MSG_MAIL_SENT'));
     }
   }
 }

--- a/components/com_joomgallery/controllers/upload.php
+++ b/components/com_joomgallery/controllers/upload.php
@@ -47,7 +47,7 @@ class JoomGalleryControllerUpload extends JControllerLegacy
       $msg  = JText::_('COM_JOOMGALLERY_UPLOAD_MSG_SUCCESSFULL');
 
       // Set redirect if we are asked for that
-      if($redirect = JRequest::getVar('redirect', '', '', 'base64'))
+      if($redirect = $this->input->getBase64('redirect', ''))
       {
         $url  = base64_decode($redirect);
         if(JURI::isInternal($url))

--- a/components/com_joomgallery/helpers/ambit.php
+++ b/components/com_joomgallery/helpers/ambit.php
@@ -277,7 +277,7 @@ class JoomAmbit extends JObject
     $types = array('thumb_path', 'thumb_url', 'img_path', 'img_url', 'orig_path', 'orig_url');
     if(!in_array($type, $types))
     {
-      JError::raiseError(500, JText::sprintf('Wrong image type: %s', $type));
+      throw new UnexpectedValueException(JText::sprintf('Wrong image type: %s', $type));
     }
 
     if(!is_object($img))
@@ -369,7 +369,7 @@ class JoomAmbit extends JObject
 
       if(!$row->load($id))
       {
-        JError::raiseError(500, JText::sprintf('Image with ID %d not found', $id));
+        throw new RuntimeException(JText::sprintf('Image with ID %d not found', $id));
       }
 
       $properties   = $row->getProperties();

--- a/components/com_joomgallery/helpers/helper.php
+++ b/components/com_joomgallery/helpers/helper.php
@@ -213,7 +213,7 @@ class JoomHelper
       $maxdate = $db->loadResult();
       if($db->getErrorNum())
       {
-        JError::raiseWarning(500, $db->getErrorMsg());
+        JFactory::getApplication()->enqueueMessage($db->getErrorMsg(), 'error');
       }
 
       // If maxdate = NULL no image found
@@ -274,7 +274,7 @@ class JoomHelper
    */
   public static function addSitenameToPagetitle($pagetitle)
   {
-    $app = JFactory::getApplication('site');
+    $app = JFactory::getApplication();
 
     if($app->getCfg('sitename_pagetitles'))
     {
@@ -493,7 +493,7 @@ class JoomHelper
    */
   public static function getModules($pos)
   {
-    $view     = JRequest::getCmd('view');
+    $view     = JFactory::getApplication()->input->getCmd('view');
 
     $position = 'jg_'.$pos;
     $modules  = & JModuleHelper::getModules($position);
@@ -565,8 +565,8 @@ class JoomHelper
   {
     $config = JoomConfig::getInstance();
     $user   = JFactory::getUser();
-    $view   = JRequest::getCmd('view');
-    $app    = JFactory::getApplication('site');
+    $app    = JFactory::getApplication();
+    $view   = $app->input->getCmd('view');
 
     // Page heading
     $menus  = $app->getMenu();

--- a/components/com_joomgallery/helpers/helper.php
+++ b/components/com_joomgallery/helpers/helper.php
@@ -478,8 +478,7 @@ class JoomHelper
       $smileys[':cry:']           = $path.'sm_cry.gif';
     }
 
-    $dispatcher = JDispatcher::getInstance();
-    $dispatcher->trigger('onJoomGetSmileys', array(&$smileys));
+    JFactory::getApplication()->triggerEvent('onJoomGetSmileys', array(&$smileys));
 
     return $smileys;
   }

--- a/components/com_joomgallery/helpers/messenger.php
+++ b/components/com_joomgallery/helpers/messenger.php
@@ -324,7 +324,7 @@ class JoomMessenger extends JObject
         ||  !$message['body']
       )
     {
-      JError::raiseNotice(500, 'Unsufficient Information to send message');
+      JFactory::getApplication()->enqueueMessage('Unsufficient Information to send message', 'notice');
       return false;
     }
 
@@ -361,7 +361,7 @@ class JoomMessenger extends JObject
 
     if(!array_key_exists($this->_mode, $this->_modes))
     {
-      JError::raiseError(500, 'Unknown JoomGallery send message mode');
+      throw new UnexpectedValueException('Unknown JoomGallery send message mode');
     }
 
     if(isset($this->_message['type']) && $this->_message['type'])
@@ -405,7 +405,7 @@ class JoomMessenger extends JObject
     }
     if(!$from)
     {
-      $mainframe  = JFactory::getApplication('site');
+      $mainframe  = JFactory::getApplication();
       $from       = $mainframe->getCfg('mailfrom');
     }
 
@@ -413,7 +413,7 @@ class JoomMessenger extends JObject
     {
       if(!isset($user) || !is_object($user))
       {
-        $mainframe  = JFactory::getApplication('site');
+        $mainframe  = JFactory::getApplication();
         $fromname   = $mainframe->getCfg('fromname');
       }
       else
@@ -563,7 +563,8 @@ class JoomMessenger extends JObject
 
     if(in_array(false, $result_array))
     {
-      JError::raiseNotice(500, $msg->getError());
+      JFactory::getApplication()->enqueueMessage($msg->getError(), 'notice');
+
       return false;
     }
 

--- a/components/com_joomgallery/helpers/messenger.php
+++ b/components/com_joomgallery/helpers/messenger.php
@@ -550,7 +550,7 @@ class JoomMessenger extends JObject
 
       // Send messages only if all plugins allow that
       // A plugin could disallow that if it sends the message via another system, for example.
-      $plugins = JDispatcher::getInstance()->trigger('onJoomBeforeSendMessage', array($message));
+      $plugins = JFactory::getApplication()->triggerEvent('onJoomBeforeSendMessage', array($message));
       if(!in_array(false, $plugins, true))
       {
         $message['user_id_to']    = $recipient;

--- a/components/com_joomgallery/helpers/routing.php
+++ b/components/com_joomgallery/helpers/routing.php
@@ -71,7 +71,7 @@ class JoomRouting
    */
   public static function checkItemid($Itemid)
   {
-    $mainframe  = JApplication::getInstance('site');
+    $mainframe  = JFactory::getApplication();
     $menu       = $mainframe->getMenu();
     $menuItem   = $menu->getItem($Itemid);
     if(!isset($menuItem->query['view']) || $menuItem->query['view'] == 'gallery')

--- a/components/com_joomgallery/interface.php
+++ b/components/com_joomgallery/interface.php
@@ -1361,7 +1361,7 @@ class JoomInterface
   public function addSearchTerms($query, $searchstring)
   {
     $aliases = array('images' => 'jg', 'categories' => 'jgc');
-    $plugins = JDispatcher::getInstance()->trigger('onJoomSearch', array($searchstring, $aliases, _JOOM_OPTION.'.interface'));
+    $plugins = JFactory::getApplication()->triggerEvent('onJoomSearch', array($searchstring, $aliases, _JOOM_OPTION.'.interface'));
 
     $searchstring = $this->_db->quote('%'.$this->_db->escape(strtolower(trim($searchstring))).'%');
 

--- a/components/com_joomgallery/joomgallery.php
+++ b/components/com_joomgallery/joomgallery.php
@@ -13,9 +13,11 @@
 
 defined('_JEXEC') or die('Direct Access to this location is not allowed.');
 
-if(version_compare(JVERSION, '4.0', 'ge') || version_compare(JVERSION, '3.0', 'lt'))
+if(version_compare(JVERSION, '5.0', 'ge') || version_compare(JVERSION, '3.0', 'lt'))
 {
-  return JError::raiseWarning(500, 'JoomGallery 3.x is only compatible to Joomla! 3.x');
+  JFactory::getApplication()->enqueueMessage('JoomGallery 4.x is only compatible to Joomla! 4.x', 'warning');
+
+  return;
 }
 
 // Require the defines

--- a/components/com_joomgallery/model.php
+++ b/components/com_joomgallery/model.php
@@ -13,8 +13,6 @@
 
 defined('_JEXEC') or die('Direct Access to this location is not allowed.');
 
-jimport('joomla.application.component.model');
-
 /**
  * JoomGallery Parent Model
  *
@@ -64,7 +62,7 @@ class JoomGalleryModel extends JModelLegacy
     $this->_ambit     = JoomAmbit::getInstance();
     $this->_config    = JoomConfig::getInstance();
 
-    $this->_mainframe = JFactory::getApplication('site');
+    $this->_mainframe = JFactory::getApplication();
     $this->_user      = JFactory::getUser();
   }
 }

--- a/components/com_joomgallery/models/category.php
+++ b/components/com_joomgallery/models/category.php
@@ -87,7 +87,7 @@ class JoomGalleryModelCategory extends JoomGalleryModel
   {
     parent::__construct();
 
-    $id = JRequest::getInt('catid', 0);
+    $id = $this->_mainframe->input->getInt('catid', 0);
     $this->setId($id);
   }
 
@@ -179,7 +179,7 @@ class JoomGalleryModelCategory extends JoomGalleryModel
     {
       // We still have to select the categories according to the pagination
       $limit      = $this->_config->get('jg_subperpage');
-      $limitstart = JRequest::getInt('catlimitstart', 0);
+      $limitstart = $this->_mainframe->input->getInt('catlimitstart', 0);
       $cats       = array_slice($this->_categorieswithoutempty, $limitstart, $limit);
 
       return $cats;
@@ -452,7 +452,7 @@ class JoomGalleryModelCategory extends JoomGalleryModel
 
       if(!$row = $this->_db->loadObject())
       {
-        JError::raiseError(500, JText::sprintf('Category with ID %d not found', $this->_id));
+        throw new RuntimeException(JText::sprintf('Category with ID %d not found', $this->_id));
       }
 
       $this->_category = $row;
@@ -465,7 +465,7 @@ class JoomGalleryModelCategory extends JoomGalleryModel
           &&  $this->_category->parent_id > 1
           &&  !isset($categories[$this->_category->parent_id]))
       {
-        JError::raiseError(500, JText::sprintf('Category with ID %d not found', $this->_id));
+        throw new RuntimeException(JText::sprintf('Category with ID %d not found', $this->_id));
       }
     }
 
@@ -484,8 +484,8 @@ class JoomGalleryModelCategory extends JoomGalleryModel
     if(empty($this->_categories))
     {
       // Get the pagination request variables
-      $limit      = $this->_config->get('jg_subperpage');#JRequest::getVar('limit', 0, '', 'int');
-      $limitstart = JRequest::getInt('catlimitstart', 0);
+      $limit      = $this->_config->get('jg_subperpage');
+      $limitstart = $this->_mainframe->input->getInt('catlimitstart', 0);
 
       $query = $this->_buildCategoriesQuery();
 
@@ -548,7 +548,7 @@ class JoomGalleryModelCategory extends JoomGalleryModel
     if(empty($this->_images))
     {
       // Get the pagination request variables
-      $limitstart = JRequest::getInt('limitstart', 0);
+      $limitstart = $this->_mainframe->input->getInt('limitstart', 0);
       if($limitstart == -1)
       {
         // If we want to display all images in a popup box we will need all images
@@ -556,7 +556,7 @@ class JoomGalleryModelCategory extends JoomGalleryModel
       }
       else
       {
-        $limit  = JRequest::getInt('limit', 0);
+        $limit  = $this->_mainframe->input->getInt('limit', 0);
       }
 
       $query = $this->_buildImagesQuery();
@@ -583,7 +583,7 @@ class JoomGalleryModelCategory extends JoomGalleryModel
     // Let's load the data if it doesn't already exist
     if(empty($this->_allimages))
     {
-      $limit = JRequest::getInt('limit', 0);
+      $limit = $this->_mainframe->input->getInt('limit', 0);
 
       if(!$limit)
       {

--- a/components/com_joomgallery/models/comments.php
+++ b/components/com_joomgallery/models/comments.php
@@ -40,7 +40,7 @@ class JoomGalleryModelComments extends JoomGalleryModel
   {
     parent::__construct();
 
-    $id = JRequest::getInt('id');
+    $id = $this->_mainframe->input->getInt('id');
     $this->setId($id);
   }
 
@@ -55,7 +55,7 @@ class JoomGalleryModelComments extends JoomGalleryModel
     // Set new image ID if valid
     if(!$id)
     {
-      JError::raiseError(500, JText::_('COM_JOOMGALLERY_COMMON_NO_IMAGE_SPECIFIED'));
+      throw new RuntimeException(JText::_('COM_JOOMGALLERY_COMMON_NO_IMAGE_SPECIFIED'));
     }
     $this->_id  = $id;
   }
@@ -109,8 +109,7 @@ class JoomGalleryModelComments extends JoomGalleryModel
     }
 
     // Comment text
-    $filter = JFilterInput::getInstance();
-    $text = trim($filter->clean(JRequest::getVar('cmttext', '', 'post')));
+    $text = trim($this->_mainframe->input->post->getString('cmttext', ''));
     if(!$text)
     {
       $this->_mainframe->redirect(JRoute::_('index.php?view=detail&id='.$this->_id.'#joomcommentform', false),
@@ -126,7 +125,7 @@ class JoomGalleryModelComments extends JoomGalleryModel
     {
       if($this->_config->get('jg_namedanoncomment'))
       {
-        $name   = trim($filter->clean(JRequest::getVar('cmtname', '', 'post')));
+        $name = trim($this->_mainframe->input->post->getString('cmtname', ''));
         if(!$name)
         {
           $name = JText::_('COM_JOOMGALLERY_COMMON_GUEST');
@@ -283,17 +282,17 @@ class JoomGalleryModelComments extends JoomGalleryModel
   {
     if(!$this->_user->authorise('core.manage', _JOOM_OPTION))
     {
-      JError::raiseError(500, JText::_('COM_JOOMGALLERY_COMMON_PERMISSION_DENIED'));
+      throw new JAccessExceptionNotallowed(JText::_('COM_JOOMGALLERY_COMMON_PERMISSION_DENIED'));
     }
 
-    $cmtid = JRequest::getInt('cmtid');
+    $cmtid = $this->_mainframe->input->getInt('cmtid');
 
     $query = $this->_db->getQuery(true)
           ->delete(_JOOM_TABLE_COMMENTS)
           ->where('cmtid = '.$cmtid)
           ->where('cmtpic  = '.$this->_id);
     $this->_db->setQuery($query);
-    if(!$this->_db->query())
+    if(!$this->_db->execute())
     {
       $this->setError(JText::_('COM_JOOMGALLERY_ERROR_DELETING_COMMENT'));
 

--- a/components/com_joomgallery/models/detail.php
+++ b/components/com_joomgallery/models/detail.php
@@ -87,8 +87,8 @@ class JoomGalleryModelDetail extends JoomGalleryModel
   {
     parent::__construct();
 
-    $id = JRequest::getVar('id', 0, '', 'int');
-    $this->setId((int)$id);
+    $id = $this->_mainframe->input->getInt('id', 0);
+    $this->setId($id);
   }
 
   /**
@@ -138,7 +138,7 @@ class JoomGalleryModelDetail extends JoomGalleryModel
       }
       else
       {
-        JError::raiseError(500, JText::_('Unable to load images'));
+        throw new RuntimeException(JText::_('Unable to load images'));
       }
 
       #$image  = $images[$this->_id]; see _loadImages()
@@ -162,7 +162,7 @@ class JoomGalleryModelDetail extends JoomGalleryModel
       $categories = $this->_ambit->getCategoryStructure();
       if(!isset($categories[$image->catid]))
       {
-        JError::raiseError(500, JText::sprintf('Unable to load image with ID %d', $this->_id), 'error');
+        throw new RuntimeException(JText::sprintf('Unable to load image with ID %d', $this->_id));
       }
 
       // Source url
@@ -423,7 +423,8 @@ class JoomGalleryModelDetail extends JoomGalleryModel
       }
       else
       {
-        JError::raiseWarning( 0, 'Unable to Load Data');
+        $this->_mainframe->enqueueMessage('Unable to Load Data', 'error');
+
         return false;
       }
     }

--- a/components/com_joomgallery/models/edit.php
+++ b/components/com_joomgallery/models/edit.php
@@ -187,23 +187,8 @@ class JoomGalleryModelEdit extends JoomGalleryModel
     // Import the appropriate plugin group
     JPluginHelper::importPlugin($group);
 
-    // Get the dispatcher
-    $dispatcher = JDispatcher::getInstance();
-
     // Trigger the form preparation event
-    $results = $dispatcher->trigger('onContentPrepareForm', array($form, $data));
-
-    // Check for errors encountered while preparing the form
-    if(count($results) && in_array(false, $results, true))
-    {
-      // Get the last error
-      $error = $dispatcher->getError();
-
-      if(!($error instanceof Exception))
-      {
-        throw new Exception($error);
-      }
-    }
+    $this->_mainframe->triggerEvent('onContentPrepareForm', array($form, $data));
   }
 
   /**

--- a/components/com_joomgallery/models/edit.php
+++ b/components/com_joomgallery/models/edit.php
@@ -161,7 +161,7 @@ class JoomGalleryModelEdit extends JoomGalleryModel
       // Unset the data of fields which we aren't allowed to change
       $form->setFieldAttribute('published', 'filter', 'unset');
     }
-    
+
     if(!$this->_config->get('jg_edit_metadata'))
     {
       $form->setFieldAttribute('metakey', 'disabled', 'true');
@@ -296,7 +296,7 @@ class JoomGalleryModelEdit extends JoomGalleryModel
 
     if(is_null($data))
     {
-      $data = JRequest::get('post', 2);
+      $data = $this->_mainframe->input->post->getArray(array(), NULL, 'RAW');
     }
 
     // Check for validation errors
@@ -553,7 +553,7 @@ class JoomGalleryModelEdit extends JoomGalleryModel
     $query->delete(_JOOM_TABLE_COMMENTS)
           ->where('cmtpic = '.$this->_id);
     $this->_db->setQuery($query);
-    if(!$this->_db->query())
+    if(!$this->_db->execute())
     {
       JLog::add(JText::sprintf('COM_JOOMGALLERY_EDITIMAGE_MSG_COULD_NOT_DELETE_COMMENTS', $this->_id), JLog::WARNING, 'jerror');
     }
@@ -563,7 +563,7 @@ class JoomGalleryModelEdit extends JoomGalleryModel
     $query->delete(_JOOM_TABLE_NAMESHIELDS)
           ->where('npicid = '.$this->_id);
     $this->_db->setQuery($query);
-    if(!$this->_db->query())
+    if(!$this->_db->execute())
     {
       JLog::add(JText::sprintf('COM_JOOMGALLERY_EDITIMAGE_MSG_COULD_NOT_DELETE_NAMETAGS', $this->_id), JLog::WARNING, 'jerror');
     }
@@ -573,7 +573,7 @@ class JoomGalleryModelEdit extends JoomGalleryModel
     $query->delete(_JOOM_TABLE_VOTES)
           ->where('picid = '.$this->_id);
     $this->_db->setQuery($query);
-    if(!$this->_db->query())
+    if(!$this->_db->execute())
     {
       JLog::add(JText::_('COM_JOOMGALLERY_EDITIMAGE_MSG_COULD_NOT_DELETE_VOTES'), JLog::WARNING, 'jerror');
     }
@@ -644,7 +644,7 @@ class JoomGalleryModelEdit extends JoomGalleryModel
     $thumb_dest     = $this->_ambit->get('thumb_path').$catpath_new.$item->imgthumbname;
     if(JFile::exists($thumb_dest))
     {
-      JError::raiseNotice(0, JText::_('COM_JOOMGALLERY_EDITIMAGE_MSG_DEST_THUMB_ALREADY_EXISTS'));
+      $this->_mainframe->enqueueMessage(JText::_('COM_JOOMGALLERY_EDITIMAGE_MSG_DEST_THUMB_ALREADY_EXISTS'), 'notice');
 
       if($thumb_count && JFile::exists($thumb_source))
       {
@@ -655,7 +655,7 @@ class JoomGalleryModelEdit extends JoomGalleryModel
     {
       if(!JFile::exists($thumb_source))
       {
-        JError::raiseWarning(500, JText::sprintf('COM_JOOMGALLERY_EDITIMAGE_MSG_SOURCE_THUMB_NOT_EXISTS', $thumb_source));
+        $this->_mainframe->enqueueMessage(JText::sprintf('COM_JOOMGALLERY_EDITIMAGE_MSG_SOURCE_THUMB_NOT_EXISTS', $thumb_source), 'error');
 
         return false;
       }
@@ -676,7 +676,7 @@ class JoomGalleryModelEdit extends JoomGalleryModel
         // If not succesful raise an error message and abort
         if(!$result)
         {
-          JError::raiseWarning(100, JText::sprintf('COM_JOOMGALLERY_EDITIMAGE_MSG_COULD_NOT_MOVE_THUMB', JPath::clean($thumb_dest)));
+          $this->_mainframe->enqueueMessage(JText::sprintf('COM_JOOMGALLERY_EDITIMAGE_MSG_COULD_NOT_MOVE_THUMB', JPath::clean($thumb_dest)), 'error');
 
           return false;
         }
@@ -702,7 +702,7 @@ class JoomGalleryModelEdit extends JoomGalleryModel
     $img_dest     = $this->_ambit->get('img_path').$catpath_new.$item->imgfilename;
     if(JFile::exists($img_dest))
     {
-      JError::raiseNotice(0, JText::_('COM_JOOMGALLERY_EDITIMAGE_MSG_DEST_IMG_ALREADY_EXISTS'));
+      $this->_mainframe->enqueueMessage(JText::_('COM_JOOMGALLERY_EDITIMAGE_MSG_DEST_IMG_ALREADY_EXISTS'), 'notice');
 
       if($img_count && JFile::exists($img_source))
       {
@@ -713,7 +713,7 @@ class JoomGalleryModelEdit extends JoomGalleryModel
     {
       if(!JFile::exists($img_source))
       {
-        JError::raiseWarning(500, JText::sprintf('COM_JOOMGALLERY_EDITIMAGE_MSG_SOURCE_IMG_NOT_EXISTS', $img_source));
+        $this->_mainframe->enqueueMessage(JText::sprintf('COM_JOOMGALLERY_EDITIMAGE_MSG_SOURCE_IMG_NOT_EXISTS', $img_source), 'error');
 
         return false;
       }
@@ -741,7 +741,7 @@ class JoomGalleryModelEdit extends JoomGalleryModel
             }
           }
 
-          JError::raiseWarning(100, JText::sprintf('COM_JOOMGALLERY_EDITIMAGE_MSG_COULD_NOT_MOVE_IMG', JPath::clean($img_dest)));
+          $this->_mainframe->enqueueMessage(JText::sprintf('COM_JOOMGALLERY_EDITIMAGE_MSG_COULD_NOT_MOVE_IMG', JPath::clean($img_dest)), 'error');
 
           return false;
         }
@@ -756,7 +756,7 @@ class JoomGalleryModelEdit extends JoomGalleryModel
     $orig_dest    = $this->_ambit->get('orig_path').$catpath_new.$item->imgfilename;
     if(JFile::exists($orig_dest))
     {
-      JError::raiseNotice(0, JText::_('COM_JOOMGALLERY_EDITIMAGE_MSG_DEST_ORIG_ALREADY_EXISTS'));
+      $this->_mainframe->enqueueMessage(JText::_('COM_JOOMGALLERY_EDITIMAGE_MSG_DEST_ORIG_ALREADY_EXISTS'), 'notice');
 
       if($img_count && JFile::exists($orig_source))
       {
@@ -800,7 +800,7 @@ class JoomGalleryModelEdit extends JoomGalleryModel
             }
           }
 
-          JError::raiseWarning(100, JText::sprintf('COM_JOOMGALLERY_EDITIMAGE_MSG_COULD_NOT_MOVE_ORIG', JPath::clean($orig_dest)));
+          $this->_mainframe->enqueueMessage(JText::sprintf('COM_JOOMGALLERY_EDITIMAGE_MSG_COULD_NOT_MOVE_ORIG', JPath::clean($orig_dest)), 'error');
 
           return false;
         }
@@ -815,7 +815,7 @@ class JoomGalleryModelEdit extends JoomGalleryModel
     // Make sure the record is valid
     if(!$item->check())
     {
-      JError::raiseWarning($item->getError());
+      $this->_mainframe->enqueueMessage($item->getError(), 'error');
 
       return false;
     }
@@ -823,7 +823,7 @@ class JoomGalleryModelEdit extends JoomGalleryModel
     // Store the entry to the database
     if(!$item->store())
     {
-      JError::raiseWarning($item->getError());
+      $this->_mainframe->enqueueMessage($item->getError(), 'error');
 
       return false;
     }

--- a/components/com_joomgallery/models/editcategory.php
+++ b/components/com_joomgallery/models/editcategory.php
@@ -201,23 +201,8 @@ class JoomGalleryModelEditcategory extends JoomGalleryModel
     // Import the appropriate plugin group
     JPluginHelper::importPlugin($group);
 
-    // Get the dispatcher
-    $dispatcher = JDispatcher::getInstance();
-
     // Trigger the form preparation event
-    $results = $dispatcher->trigger('onContentPrepareForm', array($form, $data));
-
-    // Check for errors encountered while preparing the form
-    if(count($results) && in_array(false, $results, true))
-    {
-      // Get the last error
-      $error = $dispatcher->getError();
-
-      if(!($error instanceof Exception))
-      {
-        throw new Exception($error);
-      }
-    }
+    $this->_mainframe->triggerEvent('onContentPrepareForm', array($form, $data));
   }
 
   /**

--- a/components/com_joomgallery/models/editcategory.php
+++ b/components/com_joomgallery/models/editcategory.php
@@ -53,7 +53,7 @@ class JoomGalleryModelEditcategory extends JoomGalleryModel
       throw new Exception(JText::_('COM_JOOMGALLERY_COMMON_MSG_YOU_ARE_NOT_LOGGED'));
     }
 
-    $array = JRequest::getVar('catid',  0, '', 'array');
+    $array = $this->_mainframe->input->get('catid', array(0), 'array');
 
     $this->setId($array[0]);
   }
@@ -264,7 +264,7 @@ class JoomGalleryModelEditcategory extends JoomGalleryModel
   public function store()
   {
     $row  = $this->getTable('joomgallerycategories');
-    $data = JRequest::get('post', 2);
+    $data = $this->_mainframe->input->post->getArray(array(), NULL, 'RAW');
 
     // Creating a main category means creating
     // a category in ROOT category
@@ -320,7 +320,7 @@ class JoomGalleryModelEditcategory extends JoomGalleryModel
     // Bind the form fields to the category table
     if(!$row->bind($data))
     {
-      JError::raiseError(0, $row->getError());
+      throw new RuntimeException($row->getError());
       return false;
     }
 
@@ -410,7 +410,7 @@ class JoomGalleryModelEditcategory extends JoomGalleryModel
       // Store the entry to the database in order to get the new ID
       if(!$row->store())
       {
-        JError::raiseError(0, $row->getError());
+        throw new RuntimeException($row->getError());
         return false;
       }
 
@@ -446,7 +446,7 @@ class JoomGalleryModelEditcategory extends JoomGalleryModel
         // Store the entry to the database
         if(!$row->store())
         {
-          JError::raiseError(0, $row->getError());
+          throw new RuntimeException($row->getError());
           return false;
         }
       }
@@ -468,7 +468,7 @@ class JoomGalleryModelEditcategory extends JoomGalleryModel
 
         /*if(!$row->store())
         {
-            JError::raiseError(100, $row->getError());
+            throw new RuntimeException($row->getError());
             return false;
         }*/
         $this->_mainframe->enqueueMessage(JText::_('COM_JOOMGALLERY_COMMON_MSG_NOT_ALLOWED_STORE_IMAGE_IN_CATEGORY'), 'notice');
@@ -575,7 +575,7 @@ class JoomGalleryModelEditcategory extends JoomGalleryModel
     // Store the entry to the database
     if(!$row->store())
     {
-      JError::raiseError(0, $row->getError());
+      throw new RuntimeException($row->getError());
       return false;
     }
 
@@ -715,7 +715,7 @@ class JoomGalleryModelEditcategory extends JoomGalleryModel
     $subcatids = $this->_db->loadColumn();
     if($this->_db->getErrorNum())
     {
-      JError::raiseWarning(500, $this->_db->getErrorMsg());
+      $this->_mainframe->enqueueMessage($this->_db->getErrorMsg(), 'error');
     }
 
     // Nothing found, return
@@ -737,7 +737,7 @@ class JoomGalleryModelEditcategory extends JoomGalleryModel
       $row->catpath = $catpath;
       if(!$row->store())
       {
-        JError::raiseError(500, $row->getError());
+        throw new RuntimeException($row->getError());
       }
     }
 
@@ -823,7 +823,7 @@ class JoomGalleryModelEditcategory extends JoomGalleryModel
     if($return !== true)
     {
       // If not successfull
-      JError::raiseWarning(100, $return);
+      $this->_mainframe->enqueueMessage($return, 'error');
       return false;
     }
     else
@@ -834,7 +834,7 @@ class JoomGalleryModelEditcategory extends JoomGalleryModel
       {
         // If not successful
         JFolder::move($orig_dest, $orig_src);
-        JError::raiseWarning(100, $return);
+        $this->_mainframe->enqueueMessage($return, 'error');
         return false;
       }
       else
@@ -846,7 +846,7 @@ class JoomGalleryModelEditcategory extends JoomGalleryModel
           // If not successful
           JFolder::move($orig_dest, $orig_src);
           JFolder::move($img_dest, $img_src);
-          JError::raiseWarning(100, $return);
+          $this->_mainframe->enqueueMessage($return, 'error');
           return false;
         }
       }

--- a/components/com_joomgallery/models/favourites.php
+++ b/components/com_joomgallery/models/favourites.php
@@ -91,8 +91,8 @@ class JoomGalleryModelFavourites extends JoomGalleryModel
     }
 
     // Set the image id
-    $view = JRequest::getCmd('view');
-    $task = JRequest::getCmd('task');
+    $view = $this->_mainframe->input->getCmd('view');
+    $task = $this->_mainframe->input->getCmd('task');
     if(  ($view != 'favourites' || $task == 'removeimage')
       &&  $view != 'downloadzip'
       &&  $task != 'removeall'
@@ -101,7 +101,7 @@ class JoomGalleryModelFavourites extends JoomGalleryModel
       &&  $task != 'addimages'
       )
     {
-      $id = JRequest::getInt('id');
+      $id = $this->_mainframe->input->getInt('id');
       $this->setId($id);
     }
 
@@ -152,7 +152,7 @@ class JoomGalleryModelFavourites extends JoomGalleryModel
     // Set new image ID if valid
     if(!$id)
     {
-      JError::raiseError(500, JText::_('COM_JOOMGALLERY_COMMON_NO_IMAGE_SPECIFIED'));
+      throw new RuntimeException(JText::_('COM_JOOMGALLERY_COMMON_NO_IMAGE_SPECIFIED'));
     }
     $this->_id  = $id;
   }
@@ -225,7 +225,7 @@ class JoomGalleryModelFavourites extends JoomGalleryModel
         }
 
         $this->_db->setQuery($query);
-        $return = $this->_db->query();
+        $return = $this->_db->execute();
       }
       else
       {
@@ -258,7 +258,7 @@ class JoomGalleryModelFavourites extends JoomGalleryModel
               ->set('piclist = '.$this->_db->q($this->piclist.', '.$this->_id))
               ->where('uuserid = '.$this->_user->get('id'));
         $this->_db->setQuery($query);
-        $return = $this->_db->query();
+        $return = $this->_db->execute();
       }
       else
       {
@@ -335,7 +335,7 @@ class JoomGalleryModelFavourites extends JoomGalleryModel
         }
 
         $this->_db->setQuery($query);
-        $return = $this->_db->query();
+        $return = $this->_db->execute();
       }
       else
       {
@@ -371,7 +371,7 @@ class JoomGalleryModelFavourites extends JoomGalleryModel
               ->set('piclist = '.$this->_db->q(implode(',', $new_piclist_array)))
               ->where('uuserid = '.$this->_user->get('id'));
         $this->_db->setQuery($query);
-        $return = $this->_db->query();
+        $return = $this->_db->execute();
       }
       else
       {
@@ -434,7 +434,7 @@ class JoomGalleryModelFavourites extends JoomGalleryModel
       $query->update(_JOOM_TABLE_USERS)
             ->where('uuserid = '.$this->_user->get('id'));
       $this->_db->setQuery($query);
-      if(!$this->_db->query())
+      if(!$this->_db->execute())
       {
         $this->setError($this->_db->getErrorMsg());
 
@@ -466,7 +466,7 @@ class JoomGalleryModelFavourites extends JoomGalleryModel
             ->set('piclist = NULL')
             ->where('uuserid = '.$this->_user->get('id'));
       $this->_db->setQuery($query);
-      if(!$this->_db->query())
+      if(!$this->_db->execute())
       {
         $this->setError($this->_db->getErrorMsg());
 
@@ -492,7 +492,7 @@ class JoomGalleryModelFavourites extends JoomGalleryModel
    */
   public function switchLayout()
   {
-    $layout = JRequest::getCmd('layout');
+    $layout = $this->_mainframe->input->getCmd('layout');
     if(
         ($layout && $layout == 'list')
       ||
@@ -513,7 +513,7 @@ class JoomGalleryModelFavourites extends JoomGalleryModel
             ->set('layout = '.$new_layout)
             ->where('uuserid = '.$this->_user->get('id'));
       $this->_db->setQuery($query);
-      $this->_db->query();
+      $this->_db->execute();
     }
     else
     {
@@ -656,7 +656,7 @@ class JoomGalleryModelFavourites extends JoomGalleryModel
             imagepng($imgres);
             break;
           default:
-            JError::raiseError(404, JText::sprintf('COM_JOOMGALLERY_COMMON_MSG_MIME_NOT_ALLOWED', $mime));
+            throw new UnexpectedValueException(JText::sprintf('COM_JOOMGALLERY_COMMON_MSG_MIME_NOT_ALLOWED', $mime));
             break;
         }
 
@@ -751,7 +751,7 @@ class JoomGalleryModelFavourites extends JoomGalleryModel
 
       $this->_db->setQuery($query);
     }
-    $this->_db->query();
+    $this->_db->execute();
 
     $this->_mainframe->setUserState('joom.favourites.zipname', $zipname);
 
@@ -937,7 +937,7 @@ class JoomGalleryModelFavourites extends JoomGalleryModel
               ->set('piclist = '.((count($rows)) ? $this->_db->q(trim($ids, ',')) : 'NULL'))
               ->where('uuserid = '.$this->_user->get('id'));
         $this->_db->setQuery($query);
-        $this->_db->query();
+        $this->_db->execute();
       }
 
       return true;

--- a/components/com_joomgallery/models/gallery.php
+++ b/components/com_joomgallery/models/gallery.php
@@ -95,8 +95,8 @@ class JoomGalleryModelGallery extends JoomGalleryModel
     if($this->_loadCategoriesWithoutEmpty())
     {
       // We still have to select the categories according to the pagination
-      $limit      = $this->_config->get('jg_catperpage');#JRequest::getVar('limit', 0, '', 'int');
-      $limitstart = JRequest::getInt('limitstart', 0);
+      $limit      = $this->_config->get('jg_catperpage');
+      $limitstart = $this->_mainframe->input->getInt('limitstart', 0);
       $cats       = array_slice($this->_categorieswithoutempty, $limitstart, $limit);
 
       return $cats;
@@ -180,8 +180,8 @@ class JoomGalleryModelGallery extends JoomGalleryModel
     if(empty($this->_categories))
     {
       // Get the pagination request variables
-      $limit      = $this->_config->get('jg_catperpage');#JRequest::getVar('limit', 0, '', 'int');
-      $limitstart = JRequest::getInt('limitstart', 0);
+      $limit      = $this->_config->get('jg_catperpage');
+      $limitstart = $this->_mainframe->input->getInt('limitstart', 0);
 
       $query = $this->_buildQuery();
 

--- a/components/com_joomgallery/models/image.php
+++ b/components/com_joomgallery/models/image.php
@@ -149,7 +149,7 @@ class JoomGalleryModelImage extends JoomGalleryModel
           ->delete(_JOOM_TABLE_COUNTSTOP)
           ->where('NOW() > date_add(cstime, interval '.(int) $stoptime.' SECOND)');
     $this->_db->setQuery($query);
-    $this->_db->query();
+    $this->_db->execute();
 
     // Check whether entry exists
     $query->clear()
@@ -173,7 +173,7 @@ class JoomGalleryModelImage extends JoomGalleryModel
             ->columns('csip, cssessionid, cspicid, cstime')
             ->values($this->_db->q($ip).','.$this->_db->q($session_id).','.$this->_id.', NOW()');
       $this->_db->setQuery($query);
-      $this->_db->query();
+      $this->_db->execute();
 
       return false;
     }

--- a/components/com_joomgallery/models/mini.php
+++ b/components/com_joomgallery/models/mini.php
@@ -13,6 +13,8 @@
 
 defined('_JEXEC') or die('Direct Access to this location is not allowed.');
 
+use Joomla\Utilities\ArrayHelper;
+
 /**
  * Mini Joom model
  *
@@ -46,8 +48,8 @@ class JoomGalleryModelMini extends JoomGalleryModel
     // Let's load the data if it doesn't already exist
     if(empty($this->_images))
     {
-      $limitstart = JRequest::getInt('limitstart');
-      $limit      = JRequest::getInt('limit');
+      $limitstart = $this->_mainframe->input->getInt('limitstart');
+      $limit      = $this->_mainframe->input->getInt('limit');
 
       $query = $this->_buildQuery();
 
@@ -87,7 +89,7 @@ class JoomGalleryModelMini extends JoomGalleryModel
    */
   public function getUploadCategories($catids)
   {
-    JArrayHelper::toInteger($catids);
+    ArrayHelper::toInteger($catids);
 
     $query = $this->_db->getQuery(true)
           ->select('cid, name, level, owner')
@@ -125,7 +127,7 @@ class JoomGalleryModelMini extends JoomGalleryModel
    */
   public function getParentCategories($catids)
   {
-    JArrayHelper::toInteger($catids);
+    ArrayHelper::toInteger($catids);
 
     $query = $this->_db->getQuery(true)
           ->select('cid, name, level, owner')
@@ -190,7 +192,7 @@ class JoomGalleryModelMini extends JoomGalleryModel
 
     // Filter by category
     $catid  = $this->_mainframe->getUserStateFromRequest('joom.mini.catid', 'catid', 0, 'int');
-    if($catid || JRequest::getCmd('type') == 'category')
+    if($catid || $this->_mainframe->input->getCmd('type') == 'category')
     {
       $query->where('jg.catid = '.$catid);
     }

--- a/components/com_joomgallery/models/nametags.php
+++ b/components/com_joomgallery/models/nametags.php
@@ -40,7 +40,7 @@ class JoomGalleryModelNametags extends JoomGalleryModel
   {
     parent::__construct();
 
-    $id = JRequest::getInt('id');
+    $id = $this->_mainframe->input->getInt('id');
     $this->setId((int)$id);
   }
 
@@ -55,7 +55,7 @@ class JoomGalleryModelNametags extends JoomGalleryModel
     // Set new image ID if valid
     if(!$id)
     {
-      JError::raiseError(500, JText::_('COM_JOOMGALLERY_COMMON_NO_IMAGE_SPECIFIED'));
+      throw new RuntimeException(JText::_('COM_JOOMGALLERY_COMMON_NO_IMAGE_SPECIFIED'));
     }
     $this->_id  = $id;
   }
@@ -79,14 +79,14 @@ class JoomGalleryModelNametags extends JoomGalleryModel
    */
   public function save()
   {
-    $yvalue   = JRequest::getInt('yvalue',  0, 'post');
-    $xvalue   = JRequest::getInt('xvalue',  0, 'post');
+    $yvalue   = $this->_mainframe->input->post->getInt('yvalue', 0);
+    $xvalue   = $this->_mainframe->input->post->getInt('xvalue', 0);
     $height   = $this->_config->get('jg_nameshields_height');
 
     // Access check
     if(!$by = $this->_user->get('id'))
     {
-      JError::raiseError(500, JText::_('COM_JOOMGALLERY_COMMON_PERMISSION_DENIED'));
+      throw new JAccessExceptionNotallowed(JText::_('COM_JOOMGALLERY_COMMON_PERMISSION_DENIED'));
     }
 
     // Check for hacking attempt
@@ -116,7 +116,7 @@ class JoomGalleryModelNametags extends JoomGalleryModel
 
     if($this->_config->get('jg_nameshields_others'))
     {
-      $userid = JRequest::getInt('userid');
+      $userid = $this->_mainframe->input->getInt('userid');
     }
     else
     {
@@ -271,7 +271,7 @@ class JoomGalleryModelNametags extends JoomGalleryModel
   {
     if(!$userid = $this->_user->get('id'))
     {
-      JError::raiseError(500, JText::_('COM_JOOMGALLERY_COMMON_PERMISSION_DENIED'));
+      throw new JAccessExceptionNotallowed(JText::_('COM_JOOMGALLERY_COMMON_PERMISSION_DENIED'));
     }
 
     if(!$this->_config->get('jg_nameshields_others'))
@@ -283,7 +283,7 @@ class JoomGalleryModelNametags extends JoomGalleryModel
             ->where('nuserid = '.$userid);
       $this->_db->setQuery($query);
 
-      if(!$this->_db->query())
+      if(!$this->_db->execute())
       {
         $this->setError(JText::_('COM_JOOMGALLERY_DETAIL_NAMETAGS_MSG_ERROR_DELETING'));
         return false;
@@ -291,7 +291,7 @@ class JoomGalleryModelNametags extends JoomGalleryModel
     }
     else
     {
-      $nid = JRequest::getInt('nid');
+      $nid = $this->_mainframe->input->getInt('nid');
 
       $row = $this->getTable('joomgallerynameshields');
       $row->load($nid);

--- a/components/com_joomgallery/models/report.php
+++ b/components/com_joomgallery/models/report.php
@@ -32,7 +32,7 @@ class JoomGalleryModelReport extends JoomGalleryModel
    */
   public function send($redirect_url = 'index.php')
   {
-    $id = JRequest::getInt('id');
+    $id = $this->_mainframe->input->getInt('id');
 
     if(!$id)
     {

--- a/components/com_joomgallery/models/search.php
+++ b/components/com_joomgallery/models/search.php
@@ -65,7 +65,7 @@ class JoomGalleryModelSearch extends JoomGalleryModel
   {
     if(empty($this->_searchResults))
     {
-      $sstring        = JRequest::getString('sstring');
+      $sstring        = $this->_mainframe->input->getString('sstring');
       $searchstring   = $this->_db->escape(trim($sstring));
 
       $categories           = $this->_ambit->getCategoryStructure();

--- a/components/com_joomgallery/models/send2friend.php
+++ b/components/com_joomgallery/models/send2friend.php
@@ -31,7 +31,7 @@ class JoomGalleryModelSend2Friend extends JoomGalleryModel
    */
   public function send()
   {
-    $id = JRequest::getInt('id');
+    $id = $this->_mainframe->input->getInt('id');
 
     if(!$this->_user->get('id'))
     {
@@ -49,8 +49,8 @@ class JoomGalleryModelSend2Friend extends JoomGalleryModel
 
     require_once JPATH_COMPONENT.'/helpers/messenger.php';
 
-    $send2friendname  = JRequest::getVar('send2friendname', '', 'post');
-    $send2friendemail = JRequest::getVar('send2friendemail', '', 'post');
+    $send2friendname  = $this->_mainframe->input->post->get('send2friendname', '');
+    $send2friendemail = $this->_mainframe->input->post->get('send2friendemail', '');
 
     // Prepare link
     $link = JRoute::_('index.php?view=detail&id='.$id);

--- a/components/com_joomgallery/models/usercategories.php
+++ b/components/com_joomgallery/models/usercategories.php
@@ -189,11 +189,11 @@ class JoomGalleryModelUsercategories extends JoomGalleryModel
   {
     $old_state = $this->_mainframe->getUserState($key);
     $cur_state = (!is_null($old_state)) ? $old_state : $default;
-    $new_state = JRequest::getVar($request, null, 'default', $type);
+    $new_state = $this->_mainframe->input->get($request, null, $type);
 
     if($cur_state != $new_state && !is_null($new_state) && !is_null($old_state) && $resetPage)
     {
-      JRequest::setVar('limitstart', 0);
+      $this->_mainframe->input->set('limitstart', 0);
     }
 
     // Save the new value only if it was set in this request.

--- a/components/com_joomgallery/models/userpanel.php
+++ b/components/com_joomgallery/models/userpanel.php
@@ -192,11 +192,11 @@ class JoomGalleryModelUserpanel extends JoomGalleryModel
   {
     $old_state = $this->_mainframe->getUserState($key);
     $cur_state = (!is_null($old_state)) ? $old_state : $default;
-    $new_state = JRequest::getVar($request, null, 'default', $type);
+    $new_state = $this->_mainframe->input->get($request, null, $type);
 
     if($cur_state != $new_state && !is_null($new_state) && !is_null($old_state) && $resetPage)
     {
-      JRequest::setVar('limitstart', 0);
+      $this->_mainframe->input->set('limitstart', 0);
     }
 
     // Save the new value only if it was set in this request.

--- a/components/com_joomgallery/models/vote.php
+++ b/components/com_joomgallery/models/vote.php
@@ -38,7 +38,7 @@ class JoomGalleryModelVote extends JoomGalleryModel
   {
     parent::__construct();
 
-    $id = JRequest::getInt('id');
+    $id = $this->_mainframe->input->getInt('id');
     $this->setId($id);
   }
 
@@ -105,7 +105,7 @@ class JoomGalleryModelVote extends JoomGalleryModel
       return false;
     }
 
-    $vote = JRequest::getInt('imgvote');
+    $vote = $this->_mainframe->input->getInt('imgvote');
 
     // Check if vote was manipulated with modifying the HTML code
     if($vote < 1 || $vote > $this->_config->get('jg_maxvoting'))
@@ -184,7 +184,7 @@ class JoomGalleryModelVote extends JoomGalleryModel
           ->set('imgvotesum = '.$row->imgvotesum)
           ->where('id = '.$this->_id);
     $this->_db->setQuery($query);
-    if(!$this->_db->query())
+    if(!$this->_db->execute())
     {
       $this->setError($this->_db->getErrorMsg());
 

--- a/components/com_joomgallery/router.php
+++ b/components/com_joomgallery/router.php
@@ -37,7 +37,7 @@ function JoomGalleryBuildRoute(&$query)
       switch($query['type'])
       {
         case 'toprated':
-          $segment = JApplication::stringURLSafe(JText::_('COM_JOOMGALLERY_COMMON_TOPLIST_TOP_RATED'));
+          $segment = JApplicationHelper::stringURLSafe(JText::_('COM_JOOMGALLERY_COMMON_TOPLIST_TOP_RATED'));
           if(trim(str_replace('-', '', $segment)) == '')
           {
             $segments[] = 'top-rated';
@@ -48,7 +48,7 @@ function JoomGalleryBuildRoute(&$query)
           }
           break;
         case 'lastadded':
-          $segment = JApplication::stringURLSafe(JText::_('COM_JOOMGALLERY_COMMON_TOPLIST_LAST_ADDED'));
+          $segment = JApplicationHelper::stringURLSafe(JText::_('COM_JOOMGALLERY_COMMON_TOPLIST_LAST_ADDED'));
           if(trim(str_replace('-', '', $segment)) == '')
           {
             $segments[] = 'last-added';
@@ -59,7 +59,7 @@ function JoomGalleryBuildRoute(&$query)
           }
           break;
         case 'lastcommented':
-          $segment = JApplication::stringURLSafe(JText::_('COM_JOOMGALLERY_COMMON_TOPLIST_LAST_COMMENTED'));
+          $segment = JApplicationHelper::stringURLSafe(JText::_('COM_JOOMGALLERY_COMMON_TOPLIST_LAST_COMMENTED'));
           if(trim(str_replace('-', '', $segment)) == '')
           {
             $segments[] = 'last-commented';
@@ -70,7 +70,7 @@ function JoomGalleryBuildRoute(&$query)
           }
           break;
         default:
-          $segment = JApplication::stringURLSafe(JText::_('COM_JOOMGALLERY_COMMON_TOPLIST_MOST_VIEWED'));
+          $segment = JApplicationHelper::stringURLSafe(JText::_('COM_JOOMGALLERY_COMMON_TOPLIST_MOST_VIEWED'));
           if(trim(str_replace('-', '', $segment)) == '')
           {
             $segments[] = 'most-viewed';
@@ -84,7 +84,7 @@ function JoomGalleryBuildRoute(&$query)
     }
     else
     {
-      $segment = JApplication::stringURLSafe(JText::_('COM_JOOMGALLERY_COMMON_TOPLIST_MOST_VIEWED'));
+      $segment = JApplicationHelper::stringURLSafe(JText::_('COM_JOOMGALLERY_COMMON_TOPLIST_MOST_VIEWED'));
       if(trim(str_replace('-', '', $segment)) == '')
       {
         $segments[] = 'most-viewed';
@@ -378,10 +378,10 @@ function JoomGalleryParseRoute($segments)
   $language = JFactory::getLanguage();
   $language->load('com_joomgallery');
 
-  if(   $segments[0] == str_replace('-', ':', JApplication::stringURLSafe(JText::_('COM_JOOMGALLERY_COMMON_TOPLIST_TOP_RATED')))
-    ||  $segments[0] == str_replace('-', ':', JApplication::stringURLSafe(JText::_('COM_JOOMGALLERY_COMMON_TOPLIST_LAST_ADDED')))
-    ||  $segments[0] == str_replace('-', ':', JApplication::stringURLSafe(JText::_('COM_JOOMGALLERY_COMMON_TOPLIST_LAST_COMMENTED')))
-    ||  $segments[0] == str_replace('-', ':', JApplication::stringURLSafe(JText::_('COM_JOOMGALLERY_COMMON_TOPLIST_MOST_VIEWED')))
+  if(   $segments[0] == str_replace('-', ':', JApplicationHelper::stringURLSafe(JText::_('COM_JOOMGALLERY_COMMON_TOPLIST_TOP_RATED')))
+    ||  $segments[0] == str_replace('-', ':', JApplicationHelper::stringURLSafe(JText::_('COM_JOOMGALLERY_COMMON_TOPLIST_LAST_ADDED')))
+    ||  $segments[0] == str_replace('-', ':', JApplicationHelper::stringURLSafe(JText::_('COM_JOOMGALLERY_COMMON_TOPLIST_LAST_COMMENTED')))
+    ||  $segments[0] == str_replace('-', ':', JApplicationHelper::stringURLSafe(JText::_('COM_JOOMGALLERY_COMMON_TOPLIST_MOST_VIEWED')))
     ||  $segments[0] == str_replace('-', ':', 'top-rated')
     ||  $segments[0] == str_replace('-', ':', 'last-added')
     ||  $segments[0] == str_replace('-', ':', 'last-commented')
@@ -393,15 +393,15 @@ function JoomGalleryParseRoute($segments)
     switch($segments[0])
     {
       case str_replace('-', ':', 'top-rated'):
-      case str_replace('-', ':', JApplication::stringURLSafe(JText::_('COM_JOOMGALLERY_COMMON_TOPLIST_TOP_RATED'))):
+      case str_replace('-', ':', JApplicationHelper::stringURLSafe(JText::_('COM_JOOMGALLERY_COMMON_TOPLIST_TOP_RATED'))):
         $vars['type'] = 'toprated';
         break;
       case str_replace('-', ':', 'last-added'):
-      case str_replace('-', ':', JApplication::stringURLSafe(JText::_('COM_JOOMGALLERY_COMMON_TOPLIST_LAST_ADDED'))):
+      case str_replace('-', ':', JApplicationHelper::stringURLSafe(JText::_('COM_JOOMGALLERY_COMMON_TOPLIST_LAST_ADDED'))):
         $vars['type'] = 'lastadded';
         break;
       case str_replace('-', ':', 'last-commented'):
-      case str_replace('-', ':', JApplication::stringURLSafe(JText::_('COM_JOOMGALLERY_COMMON_TOPLIST_LAST_COMMENTED'))):
+      case str_replace('-', ':', JApplicationHelper::stringURLSafe(JText::_('COM_JOOMGALLERY_COMMON_TOPLIST_LAST_COMMENTED'))):
         $vars['type'] = 'lastcommented';
         break;
       default:

--- a/components/com_joomgallery/view.php
+++ b/components/com_joomgallery/view.php
@@ -13,8 +13,6 @@
 
 defined('_JEXEC') or die('Direct Access to this location is not allowed.');
 
-jimport( 'joomla.application.component.view');
-
 /**
  * Parent HTML View Class for JoomGallery
  *
@@ -71,14 +69,18 @@ class JoomGalleryView extends JViewLegacy
     $this->_ambit     = JoomAmbit::getInstance();
     $this->_config    = JoomConfig::getInstance();
 
-    $this->_mainframe = JFactory::getApplication('site');
+    $this->_mainframe = JFactory::getApplication();
     $this->_user      = JFactory::getUser();
     $this->_doc       = JFactory::getDocument();
 
     JHtml::addIncludePath(JPATH_COMPONENT_ADMINISTRATOR.'/helpers/html');
 
     // If we are just displaying an image we don't need anything else
-    if(JRequest::getCmd('format') == 'raw' || JRequest::getCmd('format') == 'jpg' || JRequest::getCmd('format') == 'json' || JRequest::getCmd('format') == 'feed')
+    if(   $this->_mainframe->input->getCmd('format') == 'raw'
+       || $this->_mainframe->input->getCmd('format') == 'jpg'
+       || $this->_mainframe->input->getCmd('format') == 'json'
+       || $this->_mainframe->input->getCmd('format') == 'feed'
+      )
     {
       return;
     }
@@ -142,7 +144,7 @@ class JoomGalleryView extends JViewLegacy
   public function display($tpl = null)
   {
     $layout = $this->getLayout();
-    if($layout != 'default' && ($layout != 'list' || JRequest::getCmd('view') != 'favourites'))
+    if($layout != 'default' && ($layout != 'list' || $this->_mainframe->input->getCmd('view') != 'favourites'))
     {
       JFactory::getLanguage()->load('com_joomgallery.layout.'.$layout);
 

--- a/components/com_joomgallery/views/category/view.feed.php
+++ b/components/com_joomgallery/views/category/view.feed.php
@@ -37,8 +37,8 @@ class JoomGalleryViewCategory extends JoomGalleryView
     $siteEmail  = $this->_mainframe->getCfg('mailfrom');
 
     // Get the images data from the model
-    JRequest::setVar('limit', $this->_config->get('jg_category_rss'));
-    $category  = $this->get('Category');
+    $this->_mainframe->input->set('limit', $this->_config->get('jg_category_rss'));
+    $category = $this->get('Category');
     $rows     = $this->get('AllImages');
 
     $this->_doc->link = JRoute::_('index.php?view=category&catid='.$category->cid);

--- a/components/com_joomgallery/views/category/view.html.php
+++ b/components/com_joomgallery/views/category/view.html.php
@@ -30,29 +30,29 @@ class JoomGalleryViewCategory extends JoomGalleryView
    */
   public function display($tpl = null)
   {
-    $params = $this->_mainframe->getParams();
+    $this->params = $this->_mainframe->getParams();
 
     // Prepare params for header and footer
-    JoomHelper::prepareParams($params);
+    JoomHelper::prepareParams($this->params);
 
     // Load modules at position 'top'
-    $modules['top'] = JoomHelper::getRenderedModules('top');
-    if(count($modules['top']))
+    $this->modules['top'] = JoomHelper::getRenderedModules('top');
+    if(count($this->modules['top']))
     {
-      $params->set('show_top_modules', 1);
+      $this->params->set('show_top_modules', 1);
     }
     // Load modules at position 'btm'
-    $modules['btm'] = JoomHelper::getRenderedModules('btm');
-    if(count($modules['btm']))
+    $this->modules['btm'] = JoomHelper::getRenderedModules('btm');
+    if(count($this->modules['btm']))
     {
-      $params->set('show_btm_modules', 1);
+      $this->params->set('show_btm_modules', 1);
     }
 
     // Check whether this is the active menu item. This is a
     // special case in addition to code in constructor of parent class
     // because here we have to check the category ID, too.
     $active = $this->_mainframe->getMenu()->getActive();
-    if(!$active || strpos($active->link, '&catid='.JRequest::getInt('catid')) === false)
+    if(!$active || strpos($active->link, '&catid='.$this->_mainframe->input->getInt('catid')) === false)
     {
       // Get the default layout from the configuration
       if($layout = $this->_config->get('jg_alternative_layout'))
@@ -62,16 +62,18 @@ class JoomGalleryViewCategory extends JoomGalleryView
     }
 
     // Get number of images and hits in gallery
-    $numbers  = JoomHelper::getNumberOfImgHits();
+    $numbers            = JoomHelper::getNumberOfImgHits();
+    $this->numberofpics = $numbers[0];
+    $this->numberofhits = $numbers[1];
 
     // Categories pagination
     if($this->_config->get('jg_hideemptycats') == 2)
     {
-      $totalcategories = $this->get('TotalCategoriesWithoutEmpty');
+      $this->totalcategories = $this->get('TotalCategoriesWithoutEmpty');
     }
     else
     {
-      $totalcategories = $this->get('TotalCategories');
+      $this->totalcategories = $this->get('TotalCategories');
     }
 
     // Calculation of the number of total pages
@@ -80,49 +82,49 @@ class JoomGalleryViewCategory extends JoomGalleryView
     {
       $catperpage = 10;
     }
-    $cattotalpages = floor($totalcategories / $catperpage);
-    $offcut     = $totalcategories % $catperpage;
+    $this->cattotalpages = floor($this->totalcategories / $catperpage);
+    $offcut              = $this->totalcategories % $catperpage;
     if($offcut > 0)
     {
-      $cattotalpages++;
+      $this->cattotalpages++;
     }
 
-    $total = $totalcategories;
-    $totalcategories = number_format($totalcategories, 0, ',', '.');
+    $total                 = $this->totalcategories;
+    $this->totalcategories = number_format($this->totalcategories, 0, ',', '.');
     // Get the current page
-    $catpage = JRequest::getInt('catpage', 0);
-    if($catpage > $cattotalpages)
+    $this->catpage = $this->_mainframe->input->getInt('catpage', 0);
+    if($this->catpage > $this->cattotalpages)
     {
-      $catpage = $cattotalpages;
-      if($catpage <= 0)
+      $this->catpage = $this->cattotalpages;
+      if($this->catpage <= 0)
       {
-        $catpage = 1;
+        $this->catpage = 1;
       }
     }
     else
     {
-      if($catpage < 1)
+      if($this->catpage < 1)
       {
-        $catpage = 1;
+        $this->catpage = 1;
       }
     }
 
     // Limitstart
-    $limitstart = ($catpage - 1) * $catperpage;
-    JRequest::setVar('catlimitstart', $limitstart);
+    $limitstart = ($this->catpage - 1) * $catperpage;
+    $this->_mainframe->input->set('catlimitstart', $limitstart);
 
     require_once JPATH_COMPONENT_ADMINISTRATOR.'/helpers/pagination.php';
     $this->catpagination = new JoomPagination($total, $limitstart, $catperpage, 'cat', 'subcategory');
 
-    if($cattotalpages > 1 && $totalcategories != 0)
+    if($this->cattotalpages > 1 && $this->totalcategories != 0)
     {
       if($this->_config->get('jg_showpagenavsubs') <= 2)
       {
-        $params->set('show_pagination_cat_top', 1);
+        $this->params->set('show_pagination_cat_top', 1);
       }
       if($this->_config->get('jg_showpagenavsubs') >= 2)
       {
-        $params->set('show_pagination_cat_bottom', 1);
+        $this->params->set('show_pagination_cat_bottom', 1);
       }
     }
 
@@ -131,16 +133,16 @@ class JoomGalleryViewCategory extends JoomGalleryView
     {
       if($this->_config->get('jg_showpagenavsubs') <= 2)
       {
-        $params->set('show_count_cat_top', 1);
+        $this->params->set('show_count_cat_top', 1);
       }
       if($this->_config->get('jg_showpagenavsubs') >= 2)
       {
-        $params->set('show_count_cat_bottom', 1);
+        $this->params->set('show_count_cat_bottom', 1);
       }
     }
 
     // Images pagination
-    $totalimages = $this->get('TotalImages');
+    $this->totalimages = $this->get('TotalImages');
 
     // Calculation of the number of total pages
     $perpage = $this->_config->get('jg_perpage');
@@ -148,35 +150,35 @@ class JoomGalleryViewCategory extends JoomGalleryView
     {
       $perpage = 10;
     }
-    $totalpages = floor($totalimages / $perpage);
-    $offcut     = $totalimages % $perpage;
+    $this->totalpages = floor($this->totalimages / $perpage);
+    $offcut           = $this->totalimages % $perpage;
     if($offcut > 0)
     {
-      $totalpages++;
+      $this->totalpages++;
     }
 
-    $total = $totalimages;
-    $totalimages = number_format($totalimages, 0, ',', '.');
+    $total = $this->totalimages;
+    $this->totalimages = number_format($this->totalimages, 0, ',', '.');
     // Get the current page
-    $page = JRequest::getInt('page', 0);
-    if($page > $totalpages)
+    $this->page = $this->_mainframe->input->getInt('page', 0);
+    if($this->page > $this->totalpages)
     {
-      $page = $totalpages;
-      if($page <= 0)
+      $this->page = $this->totalpages;
+      if($this->page <= 0)
       {
-        $page = 1;
+        $this->page = 1;
       }
     }
     else
     {
-      if($page < 1)
+      if($this->page < 1)
       {
-        $page = 1;
+        $this->page = 1;
       }
     }
 
     // Limitstart
-    $limitstart = ($page - 1) * $perpage;
+    $limitstart = ($this->page - 1) * $perpage;
 
     $this->pagination = new JoomPagination($total, $limitstart, $perpage);
 
@@ -185,41 +187,39 @@ class JoomGalleryViewCategory extends JoomGalleryView
         &&  (!is_numeric($this->_config->get('jg_detailpic_open')) ||  $this->_config->get('jg_detailpic_open') > 4)
       )
     {
-      $params->set('show_all_in_popup', 1);
-      JRequest::setVar('limitstart', -1);
+      $this->params->set('show_all_in_popup', 1);
+      $this->_mainframe->input->set('limitstart', -1);
 
       // We need all images of this category
       $images = $this->get('Images');
 
-      $popup = array();
+      $this->popup = array();
 
-      $end    = ($page - 1) * $perpage;
-      $start  = $page * $perpage;
-      $popup['before']  = JHTML::_('joomgallery.popup', $images, 0, $end);
-      $popup['after']   = JHTML::_('joomgallery.popup', $images, $start);
-
-      $this->assignRef('popup', $popup);
+      $end    = ($this->page - 1) * $perpage;
+      $start  = $this->page * $perpage;
+      $this->popup['before']  = JHTML::_('joomgallery.popup', $images, 0, $end);
+      $this->popup['after']   = JHTML::_('joomgallery.popup', $images, $start);
 
       // Now we have to select the images according to the pagination
       $images = array_slice($images, $limitstart, $perpage);
     }
     else
     {
-      JRequest::setVar('limitstart',  $limitstart);
-      JRequest::setVar('limit',       $this->_config->get('jg_perpage'));
+      $this->_mainframe->input->set('limitstart',  $limitstart);
+      $this->_mainframe->input->set('limit',       $this->_config->get('jg_perpage'));
 
       $images = $this->get('Images');
     }
 
-    if($totalpages > 1 && $totalimages != 0)
+    if($this->totalpages > 1 && $this->totalimages != 0)
     {
       if($this->_config->get('jg_showpagenav') <= 2)
       {
-        $params->set('show_pagination_img_top', 1);
+        $this->params->set('show_pagination_img_top', 1);
       }
       if($this->_config->get('jg_showpagenav') >= 2)
       {
-        $params->set('show_pagination_img_bottom', 1);
+        $this->params->set('show_pagination_img_bottom', 1);
       }
     }
 
@@ -228,15 +228,15 @@ class JoomGalleryViewCategory extends JoomGalleryView
     {
       if($this->_config->get('jg_showpagenav') <= 2)
       {
-        $params->set('show_count_img_top', 1);
+        $this->params->set('show_count_img_top', 1);
       }
       if($this->_config->get('jg_showpagenav') >= 2)
       {
-        $params->set('show_count_img_bottom', 1);
+        $this->params->set('show_count_img_bottom', 1);
       }
     }
 
-    $cat      = $this->get('Category');
+    $cat = $this->get('Category');
 
     if(isset($cat->protected))
     {
@@ -251,15 +251,16 @@ class JoomGalleryViewCategory extends JoomGalleryView
     if($cat->parent_id > 1)
     {
       // Sub-category -> parent category
-      $backlink[0] = JRoute::_('index.php?view=category&catid='.$cat->parent_id);
-      $backlink[1] = JText::_('COM_JOOMGALLERY_COMMON_BACK_TO_CATEGORY');
+      $this->backtarget = JRoute::_('index.php?view=category&catid='.$cat->parent_id);
+      $this->backtext   = JText::_('COM_JOOMGALLERY_COMMON_BACK_TO_CATEGORY');
     }
     else
     {
       // Category view -> gallery view
-      $backlink[0] = JRoute::_('index.php?view=gallery');
-      $backlink[1] = JText::_('COM_JOOMGALLERY_COMMON_BACK_TO_GALLERY');
+      $this->backtarget = JRoute::_('index.php?view=gallery');
+      $this->backtext   = JText::_('COM_JOOMGALLERY_COMMON_BACK_TO_GALLERY');
     }
+
     // Meta data
     if($cat->metadesc)
     {
@@ -323,9 +324,10 @@ class JoomGalleryViewCategory extends JoomGalleryView
           break;
       }
     }
+
     /*if($this->_config->get('jg_completebreadcrumbs'))
     {
-      $breadcrumbs  = &$this->_mainframe->getPathway();
+      $breadcrumbs = &$this->_mainframe->getPathway();
 
       foreach($parents as $parent)
       {
@@ -336,17 +338,17 @@ class JoomGalleryViewCategory extends JoomGalleryView
     }*/
 
     // JoomGallery Pathway
-    $pathway = '';
+    $this->pathway = '';
     if($this->_config->get('jg_showpathway'))
     {
-      $pathway = '<a href="'.JRoute::_('index.php?view=gallery').'" class="jg_pathitem">'.JText::_('COM_JOOMGALLERY_COMMON_HOME').'</a> &raquo; ';
+      $this->pathway = '<a href="'.JRoute::_('index.php?view=gallery').'" class="jg_pathitem">'.JText::_('COM_JOOMGALLERY_COMMON_HOME').'</a> &raquo; ';
 
       foreach($parents as $parent)
       {
-        $pathway  .= '<a href="'.JRoute::_('index.php?view=category&catid='.$parent->cid).'" class="jg_pathitem">'.$parent->name.'</a> &raquo; ';
+        $this->pathway .= '<a href="'.JRoute::_('index.php?view=category&catid='.$parent->cid).'" class="jg_pathitem">'.$parent->name.'</a> &raquo; ';
       }
 
-      $pathway .= $cat->name;
+      $this->pathway .= $cat->name;
     }
 
     // Page title
@@ -355,7 +357,7 @@ class JoomGalleryViewCategory extends JoomGalleryView
       $pagetitle = JoomHelper::createPagetitle( $this->_config->get('jg_pagetitle_cat'),
                                                 $cat->name,
                                                 '',
-                                                $params->get('page_title') ? $params->get('page_title') : JText::_('COM_JOOMGALLERY_COMMON_GALLERY')
+                                                $this->params->get('page_title') ? $this->params->get('page_title') : JText::_('COM_JOOMGALLERY_COMMON_GALLERY')
                                               );
       $this->_doc->setTitle($pagetitle);
     }
@@ -371,8 +373,8 @@ class JoomGalleryViewCategory extends JoomGalleryView
 
       if($this->_config->get('jg_category_rss_icon'))
       {
-        $params->set('show_feed_icon', 1);
-        $params->set('feed_url', JRoute::_($link.'&type='.$this->_config->get('jg_category_rss_icon')));
+        $this->params->set('show_feed_icon', 1);
+        $this->params->set('feed_url', JRoute::_($link.'&type='.$this->_config->get('jg_category_rss_icon')));
       }
     }
 
@@ -387,11 +389,11 @@ class JoomGalleryViewCategory extends JoomGalleryView
            || ($this->_config->get('jg_usefavouritesforpubliczip') && !$this->_user->get('id'))
           )
         {
-          $params->set('show_headerfavourites_icon', 2);
+          $this->params->set('show_headerfavourites_icon', 2);
         }
         else
         {
-          $params->set('show_headerfavourites_icon', 1);
+          $this->params->set('show_headerfavourites_icon', 1);
         }
       }
       else
@@ -400,11 +402,11 @@ class JoomGalleryViewCategory extends JoomGalleryView
         {
           if($this->_config->get('jg_usefavouritesforzip'))
           {
-            $params->set('show_headerfavourites_icon', -2);
+            $this->params->set('show_headerfavourites_icon', -2);
           }
           else
           {
-            $params->set('show_headerfavourites_icon', -1);
+            $this->params->set('show_headerfavourites_icon', -1);
           }
         }
       }
@@ -417,7 +419,7 @@ class JoomGalleryViewCategory extends JoomGalleryView
             )
       )
     {
-      $params->set('show_upload_icon', 1);
+      $this->params->set('show_upload_icon', 1);
       JHtml::_('behavior.modal');
     }
 
@@ -641,7 +643,7 @@ class JoomGalleryViewCategory extends JoomGalleryView
 
             // If category view is skipped we display the favourites icon for adding all images at the thumbnail.
             // Calculations for that have already been done for the favourites icon in the header
-            $categories[$key]->show_favourites_icon = $params->get('show_headerfavourites_icon');
+            $categories[$key]->show_favourites_icon = $this->params->get('show_headerfavourites_icon');
           }
           else
           {
@@ -685,19 +687,19 @@ class JoomGalleryViewCategory extends JoomGalleryView
     {
       if($this->_user->get('id') || $this->_config->get('jg_download_unreg'))
       {
-        $params->set('show_download_icon', 1);
+        $this->params->set('show_download_icon', 1);
       }
       else
       {
         if($this->_config->get('jg_download_hint'))
         {
-          $params->set('show_download_icon', -1);
+          $this->params->set('show_download_icon', -1);
         }
       }
     }
 
     // Favourites icon
-    if(!$params->get('disable_global_info') && $this->_config->get('jg_favourites') && $this->_config->get('jg_showcategoryfavourite'))
+    if(!$this->params->get('disable_global_info') && $this->_config->get('jg_favourites') && $this->_config->get('jg_showcategoryfavourite'))
     {
       if(   $this->_user->get('id')
          || ($this->_config->get('jg_usefavouritesforpubliczip') == 1 && !$this->_user->get('id'))
@@ -707,11 +709,11 @@ class JoomGalleryViewCategory extends JoomGalleryView
            || ($this->_config->get('jg_usefavouritesforpubliczip') && !$this->_user->get('id'))
           )
         {
-          $params->set('show_favourites_icon', 2);
+          $this->params->set('show_favourites_icon', 2);
         }
         else
         {
-          $params->set('show_favourites_icon', 1);
+          $this->params->set('show_favourites_icon', 1);
         }
       }
       else
@@ -720,11 +722,11 @@ class JoomGalleryViewCategory extends JoomGalleryView
         {
           if($this->_config->get('jg_usefavouritesforzip'))
           {
-            $params->set('show_favourites_icon', -2);
+            $this->params->set('show_favourites_icon', -2);
           }
           else
           {
-            $params->set('show_favourites_icon', -1);
+            $this->params->set('show_favourites_icon', -1);
           }
         }
       }
@@ -735,7 +737,7 @@ class JoomGalleryViewCategory extends JoomGalleryView
     {
       if($this->_user->get('id') || $this->_config->get('jg_report_unreg'))
       {
-        $params->set('show_report_icon', 1);
+        $this->params->set('show_report_icon', 1);
 
         JHTML::_('behavior.modal');
       }
@@ -743,7 +745,7 @@ class JoomGalleryViewCategory extends JoomGalleryView
       {
         if($this->_config->get('jg_report_hint'))
         {
-          $params->set('show_report_icon', -1);
+          $this->params->set('show_report_icon', -1);
         }
       }
     }
@@ -861,9 +863,9 @@ class JoomGalleryViewCategory extends JoomGalleryView
                     && !$images[$key]->imgtext
                   )
              )
-          && !$params->get('show_download_icon')
-          && !$params->get('show_favourites_icon')
-          && !$params->get('show_report_icon')
+          && !$this->params->get('show_download_icon')
+          && !$this->params->get('show_favourites_icon')
+          && !$this->params->get('show_report_icon')
           && (   !$this->_config->get('jg_showcategoryeditorlinks')
                || (    $this->_config->get('jg_showcategoryeditorlinks')
                     && !$images[$key]->show_delete_icon
@@ -884,44 +886,26 @@ class JoomGalleryViewCategory extends JoomGalleryView
 
     if($this->_config->get('jg_usercatorder') && count($images))
     {
-      $orderby   = $this->_mainframe->getUserStateFromRequest('joom.category.images.orderby', 'orderby');
-      $orderdir  = $this->_mainframe->getUserStateFromRequest('joom.category.images.orderdir', 'orderdir');
+      $this->order_by   = $this->_mainframe->getUserStateFromRequest('joom.category.images.orderby', 'orderby');
+      $this->order_dir  = $this->_mainframe->getUserStateFromRequest('joom.category.images.orderdir', 'orderdir');
 
       // If subcategory navigation active insert current subcategory startpage
-      if($catpage > 1)
+      if($this->catpage > 1)
       {
-        $sort_url = JRoute::_('index.php?view=category&catid='.$cat->cid.'&catpage='.$catpage).JHTML::_('joomgallery.anchor', 'category');
+        $this->sort_url = JRoute::_('index.php?view=category&catid='.$cat->cid.'&catpage='.$this->catpage).JHTML::_('joomgallery.anchor', 'category');
       }
       else
       {
-        $sort_url = JRoute::_('index.php?view=category&catid='.$cat->cid).JHTML::_('joomgallery.anchor', 'category');
+        $this->sort_url = JRoute::_('index.php?view=category&catid='.$cat->cid).JHTML::_('joomgallery.anchor', 'category');
       }
-
-      $this->assignRef('sort_url',  $sort_url);
-      $this->assignRef('order_by',  $orderby);
-      $this->assignRef('order_dir', $orderdir);
     }
 
     // Set redirect url used in editor links to redirect back to favourites view after edit/delete
-    $redirect = '&redirect='.base64_encode(JFactory::getURI()->toString());
+    $this->redirect = '&redirect='.base64_encode(JFactory::getURI()->toString());
 
-    $this->assignRef('params',            $params);
-    $this->assignRef('category',          $cat);
-    $this->assignRef('images',            $images);
-    $this->assignRef('categories',        $categories);
-    $this->assignRef('totalimages',       $totalimages);
-    $this->assignRef('totalpages',        $totalpages);
-    $this->assignRef('page',              $page);
-    $this->assignRef('totalcategories',   $totalcategories);
-    $this->assignRef('cattotalpages',     $cattotalpages);
-    $this->assignRef('catpage',           $catpage);
-    $this->assignRef('pathway',           $pathway);
-    $this->assignRef('modules',           $modules);
-    $this->assignRef('backtarget',        $backlink[0]);
-    $this->assignRef('backtext',          $backlink[1]);
-    $this->assignRef('numberofpics',      $numbers[0]);
-    $this->assignRef('numberofhits',      $numbers[1]);
-    $this->assignRef('redirect',          $redirect);
+    $this->category   = &$cat;
+    $this->images     = &$images;
+    $this->categories = &$categories;
 
     parent::display($tpl);
   }

--- a/components/com_joomgallery/views/detail/view.html.php
+++ b/components/com_joomgallery/views/detail/view.html.php
@@ -42,10 +42,10 @@ class JoomGalleryViewDetail extends JoomGalleryView
                                   JText::_('COM_JOOMGALLERY_DETAIL_MSG_NOT_ALLOWED_VIEW_DEFAULT_DETAIL_VIEW'), 'notice');
     }
 
-    $images     = $this->get('Images');
-    $image      = $this->get('Image');
-    $slideshow  = JRequest::getInt('slideshow');
-    $params     = $this->_mainframe->getParams();
+    $this->images     = $this->get('Images');
+    $this->image      = $this->get('Image');
+    $this->slideshow  = $this->_mainframe->input->getInt('slideshow');
+    $this->params     = $this->_mainframe->getParams();
 
     // Breadcrumbs
     if(     $this->_config->get('jg_completebreadcrumbs')
@@ -53,7 +53,7 @@ class JoomGalleryViewDetail extends JoomGalleryView
         ||  $this->_config->get('jg_pagetitle_detail')
       )
     {
-      $parents  = JoomHelper::getAllParentCategories($image->catid, true);
+      $parents  = JoomHelper::getAllParentCategories($this->image->catid, true);
     }
 
     $menus = $this->_mainframe->getMenu();
@@ -72,7 +72,7 @@ class JoomGalleryViewDetail extends JoomGalleryView
             $breadcrumbs->addItem($parent->name, 'index.php?view=category&catid='.$parent->cid);
           }
 
-          $breadcrumbs->addItem($image->imgtitle);
+          $breadcrumbs->addItem($this->image->imgtitle);
           break;
         case 'category':
           $skip = true;
@@ -93,104 +93,106 @@ class JoomGalleryViewDetail extends JoomGalleryView
 
           if(!$skip)
           {
-            $breadcrumbs->addItem($image->imgtitle);
+            $breadcrumbs->addItem($this->image->imgtitle);
           }
           break;
       }
     }
 
     // JoomGallery Pathway
-    $pathway = null;
+    $this->pathway = null;
     if($this->_config->get('jg_showpathway'))
     {
-      $pathway = '<a href="'.JRoute::_('index.php?view=gallery').'" class="jg_pathitem">'.JText::_('COM_JOOMGALLERY_COMMON_HOME').'</a> &raquo; ';
+      $this->pathway = '<a href="'.JRoute::_('index.php?view=gallery').'" class="jg_pathitem">'.JText::_('COM_JOOMGALLERY_COMMON_HOME').'</a> &raquo; ';
 
       foreach($parents as $parent)
       {
-        $pathway  .= '<a href="'.JRoute::_('index.php?view=category&catid='.$parent->cid).'" class="jg_pathitem">'.$parent->name.'</a> &raquo; ';
+        $this->pathway .= '<a href="'.JRoute::_('index.php?view=category&catid='.$parent->cid).'" class="jg_pathitem">'.$parent->name.'</a> &raquo; ';
       }
 
-      $pathway .= $image->imgtitle;
+      $this->pathway .= $this->image->imgtitle;
     }
 
     // Page Title
     if($this->_config->get('jg_pagetitle_detail'))
     {
       $pagetitle  = JoomHelper::createPagetitle($this->_config->get('jg_pagetitle_detail'),
-                                                $parents[$image->catid]->name,
-                                                $image->imgtitle,
-                                                $params->get('page_title') ? $params->get('page_title') : JText::_('COM_JOOMGALLERY_COMMON_GALLERY')
+                                                $parents[$this->image->catid]->name,
+                                                $this->image->imgtitle,
+                                                $this->params->get('page_title') ? $this->params->get('page_title') : JText::_('COM_JOOMGALLERY_COMMON_GALLERY')
                                               );
       $this->_doc->setTitle($pagetitle);
     }
 
     // Header and footer
-    JoomHelper::prepareParams($params);
+    JoomHelper::prepareParams($this->params);
 
     // Generate the backlink
     if($this->_config->get('jg_skipcatview'))
     {
-      $allsubcats = JoomHelper::getAllSubCategories($image->catid, false);
+      $allsubcats = JoomHelper::getAllSubCategories($this->image->catid, false);
       // Link to category view if it include subcategories
       if(count($allsubcats))
       {
-        $backtarget = JRoute::_('index.php?view=category&catid='.$image->catid);
-        $backtext   = JText::_('COM_JOOMGALLERY_COMMON_BACK_TO_CATEGORY');
+        $this->backtarget = JRoute::_('index.php?view=category&catid='.$this->image->catid);
+        $this->backtext   = JText::_('COM_JOOMGALLERY_COMMON_BACK_TO_CATEGORY');
       }
       else
       {
         // Get the parents including category itself if not read before
         if(!isset($parents))
         {
-          $parents  = JoomHelper::getAllParentCategories($image->catid, true);
+          $parents  = JoomHelper::getAllParentCategories($this->image->catid, true);
         }
         if(count($parents) == 1)
         {
           // Link to gallery view
-          $backtarget = JRoute::_('index.php?view=gallery');
-          $backtext   = JText::_('COM_JOOMGALLERY_COMMON_BACK_TO_GALLERY');
+          $this->backtarget = JRoute::_('index.php?view=gallery');
+          $this->backtext   = JText::_('COM_JOOMGALLERY_COMMON_BACK_TO_GALLERY');
         }
         else
         {
           // Link to parent of category
-          $backtarget = JRoute::_('index.php?view=category&catid='.$parents[$image->catid]->parent_id);
-          $backtext   = JText::_('COM_JOOMGALLERY_COMMON_BACK_TO_CATEGORY');
+          $this->backtarget = JRoute::_('index.php?view=category&catid='.$parents[$this->image->catid]->parent_id);
+          $this->backtext   = JText::_('COM_JOOMGALLERY_COMMON_BACK_TO_CATEGORY');
         }
       }
     }
     else
     {
-      $backtarget = JRoute::_('index.php?view=category&catid='.$image->catid);
-      $backtext   = JText::_('COM_JOOMGALLERY_COMMON_BACK_TO_CATEGORY');
+      $this->backtarget = JRoute::_('index.php?view=category&catid='.$this->image->catid);
+      $this->backtext   = JText::_('COM_JOOMGALLERY_COMMON_BACK_TO_CATEGORY');
     }
 
     // Get number of images and hits in gallery
-    $numbers  = JoomHelper::getNumberOfImgHits();
+    $numbers            = JoomHelper::getNumberOfImgHits();
+    $this->numberofpics = $numbers[0];
+    $this->numberofhits = $numbers[1];
 
     // Load modules at position 'top'
-    $modules['top'] = JoomHelper::getRenderedModules('top');
-    if(count($modules['top']))
+    $this->modules['top'] = JoomHelper::getRenderedModules('top');
+    if(count($this->modules['top']))
     {
-      $params->set('show_top_modules', 1);
+      $this->params->set('show_top_modules', 1);
     }
     // Load modules at position 'btm'
-    $modules['btm'] = JoomHelper::getRenderedModules('btm');
-    if(count($modules['btm']))
+    $this->modules['btm'] = JoomHelper::getRenderedModules('btm');
+    if(count($this->modules['btm']))
     {
-      $params->set('show_btm_modules', 1);
+      $this->params->set('show_btm_modules', 1);
     }
     // Load modules at position 'detailbtm'
-    $modules['detailbtm'] = JoomHelper::getRenderedModules('detailbtm');
-    if(count($modules['detailbtm']))
+    $this->modules['detailbtm'] = JoomHelper::getRenderedModules('detailbtm');
+    if(count($this->modules['detailbtm']))
     {
-      $params->set('show_detailbtm_modules', 1);
+      $this->params->set('show_detailbtm_modules', 1);
     }
 
     // Check whether this is the active menu item. This is a
     // special case in addition to code in constructor of parent class
     // because here we have to check the image ID, too.
     $active = $this->_mainframe->getMenu()->getActive();
-    if(!$active || strpos($active->link, '&id='.JRequest::getInt('id')) === false)
+    if(!$active || strpos($active->link, '&id='.$this->_mainframe->input->getInt('id')) === false)
     {
       // Get the default layout from the configuration
       if($layout = $this->_config->get('jg_alternative_layout'))
@@ -200,49 +202,49 @@ class JoomGalleryViewDetail extends JoomGalleryView
     }
 
     // Meta data
-    if($image->metadesc)
+    if($this->image->metadesc)
     {
-      $this->_doc->setDescription($image->metadesc);
+      $this->_doc->setDescription($this->image->metadesc);
     }
-    elseif($image->catmetadesc)
+    elseif($this->image->catmetadesc)
     {
-      $this->_doc->setDescription($image->catmetadesc);
+      $this->_doc->setDescription($this->image->catmetadesc);
     }
-    if($image->metakey)
+    if($this->image->metakey)
     {
-      $this->_doc->setMetadata('keywords', $image->metakey);
+      $this->_doc->setMetadata('keywords', $this->image->metakey);
     }
-    elseif($image->catmetakey)
+    elseif($this->image->catmetakey)
     {
-      $this->_doc->setMetadata('keywords', $image->catmetakey);
+      $this->_doc->setMetadata('keywords', $this->image->catmetakey);
     }
-    if($this->_mainframe->getCfg('MetaAuthor') == '1' && $image->author && strcmp(JText::_('COM_JOOMGALLERY_COMMON_NO_DATA'), $image->author) != 0)
+    if($this->_mainframe->getCfg('MetaAuthor') == '1' && $this->image->author && strcmp(JText::_('COM_JOOMGALLERY_COMMON_NO_DATA'), $this->image->author) != 0)
     {
-      $this->_doc->setMetaData('author', $image->author);
+      $this->_doc->setMetaData('author', $this->image->author);
     }
 
     // Show fulltext of description
-    $image->imgtext = JoomHelper::getFulltext($image->imgtext);
+    $this->image->imgtext = JoomHelper::getFulltext($this->image->imgtext);
 
     // Set the title attribute in a tag with title and/or description of image
     // if a box is activated
     if(    (!is_numeric($this->_config->get('jg_bigpic_open')) || $this->_config->get('jg_bigpic_open') > 1)
-        && !$slideshow
+        && !$this->slideshow
       )
     {
-      $image->atagtitle =  JHTML::_('joomgallery.getTitleforATag', $image);
+      $this->image->atagtitle =  JHTML::_('joomgallery.getTitleforATag', $this->image);
     }
     else
     {
       // Set the imgtitle by default
-      $image->atagtitle = 'title="'.$image->imgtitle.'"';
+      $this->image->atagtitle = 'title="'.$this->image->imgtitle.'"';
     }
 
     // Accordion
     if($this->_config->get('jg_showdetailaccordion'))
     {
-      $toggler = 'class="joomgallery-toggler"';
-      $slider  = 'class="joomgallery-slider"';
+      $this->toggler = 'class="joomgallery-toggler"';
+      $this->slider  = 'class="joomgallery-slider"';
       JHtml::_('behavior.framework', true);
       $accordionscript= 'window.addEvent(\'domready\', function(){
         new Fx.Accordion
@@ -271,75 +273,74 @@ class JoomGalleryViewDetail extends JoomGalleryView
     }
     else
     {
-      $toggler = '';
-      $slider  = '';
+      $this->toggler = '';
+      $this->slider  = '';
     }
 
     // Linked
     if( (     ($this->_config->get('jg_bigpic') == 1 && $this->_user->get('id'))
           ||  ($this->_config->get('jg_bigpic_unreg') == 1 && !$this->_user->get('id'))
         )
-        && !$slideshow
-        && $image->bigger_orig
+        && !$this->slideshow
+        && $this->image->bigger_orig
         &&
         (     !$this->_config->get('jg_nameshields')
           || (!$this->_config->get('jg_show_nameshields_unreg') && !$this->_user->get('id'))
         )
       )
     {
-      $params->set('image_linked', 1);
+      $this->params->set('image_linked', 1);
     }
 
     // Original size
-    if(     $image->orig_exists
+    if(     $this->image->orig_exists
         &&  $this->_config->get('jg_showoriginalfilesize')
-        && !$slideshow
+        && !$this->slideshow
       )
     {
-      $params->set('show_original_size', 1);
+      $this->params->set('show_original_size', 1);
     }
 
     // Pagination
-    if(isset($images[$image->position-1]) && !$slideshow)
+    if(isset($this->images[$this->image->position-1]) && !$this->slideshow)
     {
-      $params->set('show_previous_link', 1);
-      $pagination['previous']['link'] = JRoute::_('index.php?view=detail&id='.$images[$image->position-1]->id).JHTML::_('joomgallery.anchor');
+      $this->params->set('show_previous_link', 1);
+      $this->pagination['previous']['link'] = JRoute::_('index.php?view=detail&id='.$this->images[$this->image->position-1]->id).JHTML::_('joomgallery.anchor');
       if($this->_config->get('jg_showdetailnumberofpics'))
       {
-        $params->set('show_previous_text', 1);
-        $pagination['previous']['text'] = JText::sprintf('COM_JOOMGALLERY_DETAIL_IMG_IMAGE_OF_IMAGES', $image->position, count($images));
+        $this->params->set('show_previous_text', 1);
+        $this->pagination['previous']['text'] = JText::sprintf('COM_JOOMGALLERY_DETAIL_IMG_IMAGE_OF_IMAGES', $this->image->position, count($this->images));
       }
     }
-    if(isset($images[$image->position+1]) && !$slideshow)
+    if(isset($this->images[$this->image->position+1]) && !$this->slideshow)
     {
-      $params->set('show_next_link', 1);
-      $pagination['next']['link'] = JRoute::_('index.php?view=detail&id='.$images[$image->position+1]->id).JHTML::_('joomgallery.anchor');
+      $this->params->set('show_next_link', 1);
+      $this->pagination['next']['link'] = JRoute::_('index.php?view=detail&id='.$this->images[$this->image->position+1]->id).JHTML::_('joomgallery.anchor');
       if($this->_config->get('jg_showdetailnumberofpics'))
       {
-        $params->set('show_next_text', 1);
-        $pagination['next']['text'] = JText::sprintf('COM_JOOMGALLERY_DETAIL_IMG_IMAGE_OF_IMAGES', $image->position+2, count($images));
+        $this->params->set('show_next_text', 1);
+        $this->pagination['next']['text'] = JText::sprintf('COM_JOOMGALLERY_DETAIL_IMG_IMAGE_OF_IMAGES', $this->image->position+2, count($this->images));
       }
     }
 
     // Nametags
-    if(     !$slideshow
+    if(     !$this->slideshow
         &&  ( ($this->_config->get('jg_nameshields') && $this->_user->get('id'))
           ||  ($this->_config->get('jg_nameshields_unreg') && !$this->_user->get('id'))
             )
       )
     {
-      $nametags       = $this->get('Nametags');
+      $this->nametags = $this->get('Nametags');
 
-      if($this->_user->get('id') || $nametags)
+      if($this->_user->get('id') || $this->nametags)
       {
-        $params->set('show_nametags', 1);
-        $this->assignRef('nametags', $nametags);
+        $this->params->set('show_nametags', 1);
       }
 
       $already_tagged = false;
-      foreach($nametags as $nametag)
+      foreach($this->nametags as $this->nametag)
       {
-        if($nametag->nuserid == $this->_user->get('id'))
+        if($this->nametag->nuserid == $this->_user->get('id'))
         {
           $already_tagged = true;
           break;
@@ -348,18 +349,17 @@ class JoomGalleryViewDetail extends JoomGalleryView
 
       if(     $this->_config->get('jg_nameshields')
           &&  $this->_user->get('id')
-          && !$slideshow
+          && !$this->slideshow
           && (!$already_tagged || $this->_config->get('jg_nameshields_others'))
         )
       {
-        $params->set('show_movable_nametag', 1);
+        $this->params->set('show_movable_nametag', 1);
 
-        $length             = strlen($this->_user->get('username')) * $this->_config->get('jg_nameshields_width');
-        $nametag            = array();
-        $nametag['length']  = $length;
-        $nametag['name']    = $this->_user->get('username');
-        $nametag['link']    = JRoute::_('index.php?task=nametags.save');
-        $this->assignRef('nametag', $nametag);
+        $length                   = strlen($this->_user->get('username')) * $this->_config->get('jg_nameshields_width');
+        $this->nametag            = array();
+        $this->nametag['length']  = $length;
+        $this->nametag['name']    = $this->_user->get('username');
+        $this->nametag['link']    = JRoute::_('index.php?task=nametags.save');
 
         JHtml::_('behavior.framework');
         if($this->_config->get('jg_nameshields_others'))
@@ -374,9 +374,9 @@ class JoomGalleryViewDetail extends JoomGalleryView
     // Slideshow
     if($this->_config->get('jg_slideshow'))
     {
-      $params->set('slideshow_enabled', 1);
+      $this->params->set('slideshow_enabled', 1);
 
-      if($slideshow)
+      if($this->slideshow)
       {
         JHtml::_('behavior.framework', true);
         $this->_doc->addStyleSheet($this->_ambit->getScript('smoothgallery/css/jd.gallery.css'));
@@ -436,7 +436,7 @@ class JoomGalleryViewDetail extends JoomGalleryView
         $maxwidth    = 0;
         $maxheight   = 0;
         $imgstartidx = 0;
-        foreach($images as $row)
+        foreach($this->images as $row)
         {
           // Description
           if($row->imgtext != '')
@@ -551,7 +551,7 @@ class JoomGalleryViewDetail extends JoomGalleryView
             "'.JHTML::_('joomgallery.openimage', 0, $row).'"
           );';
           // set start image index for slideshow
-          if($row->id == $image->id)
+          if($row->id == $this->image->id)
           {
             $imgstartidx = $number;
           }
@@ -635,22 +635,22 @@ class JoomGalleryViewDetail extends JoomGalleryView
     }
 
     // Icons
-    if(!$slideshow)
+    if(!$this->slideshow)
     {
       // Zoom
-      if($image->bigger_orig)
+      if($this->image->bigger_orig)
       {
         if(    ($this->_config->get('jg_bigpic') == 1 && $this->_user->get('id'))
             || ($this->_config->get('jg_bigpic_unreg') == 1 && !$this->_user->get('id'))
           )
         {
-          $params->set('show_zoom_icon', 1);
+          $this->params->set('show_zoom_icon', 1);
         }
         else
         {
           if($this->_config->get('jg_bigpic') == 1 && !$this->_user->get('id'))
           {
-            $params->set('show_zoom_icon', -1);
+            $this->params->set('show_zoom_icon', -1);
           }
         }
       }
@@ -658,19 +658,19 @@ class JoomGalleryViewDetail extends JoomGalleryView
       // Download icon
       if(   $this->_config->get('jg_download')
         &&  $this->_config->get('jg_showdetaildownload')
-        &&  ($image->orig_exists || $this->_config->get('jg_downloadfile') != 1)
+        &&  ($this->image->orig_exists || $this->_config->get('jg_downloadfile') != 1)
         )
       {
         if($this->_user->get('id') || $this->_config->get('jg_download_unreg'))
         {
-          $params->set('show_download_icon', 1);
-          $params->set('download_link', JRoute::_('index.php?task=download&id='.$image->id));
+          $this->params->set('show_download_icon', 1);
+          $this->params->set('download_link', JRoute::_('index.php?task=download&id='.$this->image->id));
         }
         else
         {
           if($this->_config->get('jg_download_hint'))
           {
-            $params->set('show_download_icon', -1);
+            $this->params->set('show_download_icon', -1);
           }
         }
       }
@@ -682,17 +682,17 @@ class JoomGalleryViewDetail extends JoomGalleryView
         {
           if(!$already_tagged)
           {
-            $params->set('show_nametag_icon', 1);
+            $this->params->set('show_nametag_icon', 1);
           }
           else
           {
-            $params->set('show_nametag_icon', 2);
-            $params->set('nametag_link', JRoute::_('index.php?task=nametags.remove&id='.$image->id, false));
+            $this->params->set('show_nametag_icon', 2);
+            $this->params->set('nametag_link', JRoute::_('index.php?task=nametags.remove&id='.$this->image->id, false));
           }
         }
         else
         {
-          $params->set('show_nametag_icon', 3);
+          $this->params->set('show_nametag_icon', 3);
         }
       }
       else
@@ -702,27 +702,27 @@ class JoomGalleryViewDetail extends JoomGalleryView
             && $this->_config->get('jg_show_nameshields_unreg')
           )
         {
-          $params->set('show_nametag_icon', -1);
+          $this->params->set('show_nametag_icon', -1);
         }
       }
 
       // Favourites
-      if(!$params->get('disable_global_info') && $this->_config->get('jg_favourites'))
+      if(!$this->params->get('disable_global_info') && $this->_config->get('jg_favourites'))
       {
         if(   $this->_user->get('id')
            || ($this->_config->get('jg_usefavouritesforpubliczip') == 1 && !$this->_user->get('id'))
           )
         {
-          $params->set('favourites_link', JRoute::_('index.php?task=favourites.addimage&id='.$image->id));
+          $this->params->set('favourites_link', JRoute::_('index.php?task=favourites.addimage&id='.$this->image->id));
           if(     $this->_config->get('jg_usefavouritesforzip') == 1
               || ($this->_config->get('jg_usefavouritesforpubliczip') == 1 && !$this->_user->get('id'))
             )
           {
-            $params->set('show_favourites_icon', 2);
+            $this->params->set('show_favourites_icon', 2);
           }
           else
           {
-            $params->set('show_favourites_icon', 1);
+            $this->params->set('show_favourites_icon', 1);
           }
         }
         else
@@ -731,11 +731,11 @@ class JoomGalleryViewDetail extends JoomGalleryView
           {
             if($this->_config->get('jg_usefavouritesforzip') == 1)
             {
-              $params->set('show_favourites_icon', -2);
+              $this->params->set('show_favourites_icon', -2);
             }
             else
             {
-              $params->set('show_favourites_icon', -1);
+              $this->params->set('show_favourites_icon', -1);
             }
           }
         }
@@ -746,7 +746,7 @@ class JoomGalleryViewDetail extends JoomGalleryView
       {
         if($this->_user->get('id') || $this->_config->get('jg_report_unreg'))
         {
-          $params->set('show_report_icon', 1);
+          $this->params->set('show_report_icon', 1);
 
           JHTML::_('behavior.modal');
         }
@@ -754,7 +754,7 @@ class JoomGalleryViewDetail extends JoomGalleryView
         {
           if($this->_config->get('jg_report_hint'))
           {
-            $params->set('show_report_icon', -1);
+            $this->params->set('show_report_icon', -1);
           }
         }
       }
@@ -764,57 +764,55 @@ class JoomGalleryViewDetail extends JoomGalleryView
          && $this->_config->get('jg_userspace') == 1
         )
       {
-        if( (   $this->_user->authorise('core.edit', _JOOM_OPTION.'.image.'.$image->id)
-            ||  (   $this->_user->authorise('core.edit.own', _JOOM_OPTION.'.image.'.$image->id)
-                &&  $image->imgowner
-                &&  $image->imgowner == $this->_user->get('id')
+        if( (   $this->_user->authorise('core.edit', _JOOM_OPTION.'.image.'.$this->image->id)
+            ||  (   $this->_user->authorise('core.edit.own', _JOOM_OPTION.'.image.'.$this->image->id)
+                &&  $this->image->imgowner
+                &&  $this->image->imgowner == $this->_user->get('id')
                 )
             )
         )
         {
-          $params->set('show_edit_icon', 1);
+          $this->params->set('show_edit_icon', 1);
         }
 
-        if($this->_user->authorise('core.delete', _JOOM_OPTION.'.image.'.$image->id))
+        if($this->_user->authorise('core.delete', _JOOM_OPTION.'.image.'.$this->image->id))
         {
-          $params->set('show_delete_icon', 1);
+          $this->params->set('show_delete_icon', 1);
         }
       }
     }
 
-    $extra = '';
+    $this->extra = '';
     if($this->_config->get('jg_disable_rightclick_detail') == 1)
     {
-      $extra = 'onmouseover="javascript:joom_hover();" onmouseout="javascript:joom_hover();"';
+      $this->extra = 'onmouseover="javascript:joom_hover();" onmouseout="javascript:joom_hover();"';
     }
 
-    $event = new stdClass();
+    $this->event = new stdClass();
 
-    if(!$slideshow)
+    if(!$this->slideshow)
     {
       if($this->_config->get('jg_lightbox_slide_all'))
       {
-        $params->set('show_all_in_popup', 1);
+        $this->params->set('show_all_in_popup', 1);
 
-        $popup = array();
+        $this->popup = array();
 
-        $popup['before']  = JHTML::_('joomgallery.popup', $images, 0, $image->position, $params->get('image_linked') ? 'joomgalleryIcon' : null);
-        $popup['after']   = JHTML::_('joomgallery.popup', $images, $image->position + 1, null, $params->get('image_linked') ? 'joomgalleryIcon' : null);
-
-        $this->assignRef('popup', $popup);
+        $this->popup['before']  = JHTML::_('joomgallery.popup', $this->images, 0, $this->image->position, $this->params->get('image_linked') ? 'joomgalleryIcon' : null);
+        $this->popup['after']   = JHTML::_('joomgallery.popup', $this->images, $this->image->position + 1, null, $this->params->get('image_linked') ? 'joomgalleryIcon' : null);
       }
 
       // Pane
       // Load modules at position 'detailpane'
-      $modules['detailpane'] = JoomHelper::getRenderedModules('detailpane');
-      if(count($modules['detailpane']))
+      $this->modules['detailpane'] = JoomHelper::getRenderedModules('detailpane');
+      if(count($this->modules['detailpane']))
       {
-        $params->set('show_detailpane_modules', 1);
+        $this->params->set('show_detailpane_modules', 1);
       }
 
       // Exif data
       if(    $this->_config->get('jg_showexifdata')
-          && $image->orig_exists
+          && $this->image->orig_exists
           && extension_loaded('exif')
           && function_exists('exif_read_data')
         )
@@ -822,14 +820,14 @@ class JoomGalleryViewDetail extends JoomGalleryView
         $exifdata = $this->get('Exifdata');
         if($exifdata)
         {
-          $params->set('show_exifdata', 1);
-          $this->assignRef('exifdata', $exifdata);
+          $this->params->set('show_exifdata', 1);
+          $this->exifdata = &$exifdata;
         }
       }
 
       // GeoTagging data
       if(    $this->_config->get('jg_showgeotagging')
-          && $image->orig_exists
+          && $this->image->orig_exists
           && extension_loaded('exif')
           && function_exists('exif_read_data')
         )
@@ -867,8 +865,8 @@ class JoomGalleryViewDetail extends JoomGalleryView
 
           if($mapdata)
           {
-            $params->set('show_map', 1);
-            $this->assignRef('mapdata', $mapdata);
+            $this->params->set('show_map', 1);
+            $this->mapdata = $mapdata;
 
             $apikey = $this->_config->get('jg_geotaggingkey');
             $this->_doc->addScript('http'.(JUri::getInstance()->isSSL() ? 's' : '').'://maps.google.com/maps/api/js?sensor=false'.(!empty($apikey) ? '&amp;key='.$apikey : ''));
@@ -880,14 +878,14 @@ class JoomGalleryViewDetail extends JoomGalleryView
 
       // IPTC data
       if(    $this->_config->get('jg_showiptcdata')
-          && $image->orig_exists
+          && $this->image->orig_exists
         )
       {
         $iptcdata = $this->get('Iptcdata');
         if($iptcdata)
         {
-          $params->set('show_iptcdata', 1);
-          $this->assignRef('iptcdata', $iptcdata);
+          $this->params->set('show_iptcdata', 1);
+          $this->iptcdata = $iptcdata;
         }
       }
 
@@ -897,53 +895,48 @@ class JoomGalleryViewDetail extends JoomGalleryView
         if($this->_config->get('jg_votingonlyreg') && !$this->_user->get('id'))
         {
           // Set voting_area to 3 to show only the message in template
-          $params->set('show_voting_area', 3);
-          $params->set('voting_message', JText::_('COM_JOOMGALLERY_DETAIL_LOGIN_FIRST'));
+          $this->params->set('show_voting_area', 3);
+          $this->params->set('voting_message', JText::_('COM_JOOMGALLERY_DETAIL_LOGIN_FIRST'));
         }
         else
         {
-          if($this->_config->get('jg_votingonlyreg') && $image->owner == $this->_user->get('id'))
+          if($this->_config->get('jg_votingonlyreg') && $this->image->owner == $this->_user->get('id'))
           {
             // Set voting_area to 3 to show only the message in template
-            $params->set('show_voting_area', 3);
-            $params->set('voting_message', JText::_('COM_JOOMGALLERY_DETAIL_RATING_NOT_ON_OWN_IMAGES'));
+            $this->params->set('show_voting_area', 3);
+            $this->params->set('voting_message', JText::_('COM_JOOMGALLERY_DETAIL_RATING_NOT_ON_OWN_IMAGES'));
           }
           else
           {
             // Set to 1 will show the voting area
             JHtml::_('behavior.framework');
-            $params->set('show_voting_area', 1);
-            $params->set('ajaxvoting', $this->_config->get('jg_ajaxrating'));
+            $this->params->set('show_voting_area', 1);
+            $this->params->set('ajaxvoting', $this->_config->get('jg_ajaxrating'));
             if($this->_config->get('jg_ratingdisplaytype') == 0)
             {
               // Set to 0 will show textual voting bar with radio buttons
-              $params->set('voting_display_type', 0);
+              $this->params->set('voting_display_type', 0);
 
-              $selected = floor($this->_config->get('jg_maxvoting') / 2) + 1;
-              $voting   = '';
+              $selected       = floor($this->_config->get('jg_maxvoting') / 2) + 1;
+              $this->voting   = '';
 
               $options = array();
               for($i = 1; $i <= $this->_config->get('jg_maxvoting'); $i++)
               {
                 $options[] = JHTML::_('select.option', $i);
                 // Delete options text manually, because it defaults to the value in JHTML::_('select.option'... ) if left empty
-                $options[$i-1]->text = '';
+                $options[$i - 1]->text = '';
               }
-              $voting .= JHTML::_('select.radiolist', $options, 'imgvote', null, 'value', 'text', $selected);
+              $this->voting .= JHTML::_('select.radiolist', $options, 'imgvote', null, 'value', 'text', $selected);
 
-              $maxvoting = $i-1;
-
-              $this->assignRef('voting', $voting);
-              $this->assignRef('maxvoting', $maxvoting);
+              $this->maxvoting = $i - 1;
             }
             else if($this->_config->get('jg_ratingdisplaytype') == 1)
             {
               // Set to 1 will show graphical voting bar with stars
-              $params->set('voting_display_type', 1);
+              $this->params->set('voting_display_type', 1);
 
-              $maxvoting = $this->_config->get('jg_maxvoting');
-
-              $this->assignRef('maxvoting', $maxvoting);
+              $this->maxvoting = $this->_config->get('jg_maxvoting');
             }
           }
         }
@@ -955,63 +948,62 @@ class JoomGalleryViewDetail extends JoomGalleryView
         $current_host   = $current_uri->getHost();
         $current_scheme = $current_uri->getScheme();
 
-        $params->set('show_bbcode', 1);
+        $this->params->set('show_bbcode', 1);
 
         if(    $this->_config->get('jg_bbcodelink') == 1
             || $this->_config->get('jg_bbcodelink') == 3
           )
         {
           // Ensure that the correct host and path is prepended
-          $uri = JFactory::getUri($image->img_src);
+          $uri = JFactory::getUri($this->image->img_src);
           $uri->setScheme($current_scheme);
           $uri->setHost($current_host);
-          $params->set('bbcode_img', str_replace('&', '&amp;', $uri->toString()));
+          $this->params->set('bbcode_img', str_replace('&', '&amp;', $uri->toString()));
         }
 
         if(    $this->_config->get('jg_bbcodelink') == 2
             || $this->_config->get('jg_bbcodelink') == 3
           )
         {
-          $url = JRoute::_('index.php?view=detail&id='.$image->id).JHTML::_('joomgallery.anchor');
+          $url = JRoute::_('index.php?view=detail&id='.$this->image->id).JHTML::_('joomgallery.anchor');
 
           // Ensure that the correct host and path is prepended
           $uri = JFactory::getUri($url);
           $uri->setScheme($current_scheme);
           $uri->setHost($current_host);
-          $params->set('bbcode_url', str_replace('&', '&amp;', $uri->toString()));
+          $this->params->set('bbcode_url', str_replace('&', '&amp;', $uri->toString()));
         }
       }
 
       if($this->_config->get('jg_showcomment'))
       {
-        $params->set('show_comments_block', 1);
+        $this->params->set('show_comments_block', 1);
 
         // Check whether user is allowed to comment
         if(      $this->_config->get('jg_anoncomment')
             || (!$this->_config->get('jg_anoncomment') && $this->_user->get('id'))
           )
         {
-          $params->set('commenting_allowed', 1);
+          $this->params->set('commenting_allowed', 1);
 
           $plugins          = $this->_mainframe->triggerEvent('onJoomGetCaptcha');
-          $event->captchas  = implode('', $plugins);
+          $this->event->captchas  = implode('', $plugins);
 
-          $this->_doc->addScriptDeclaration('    var jg_use_code = '.$params->get('use_easycaptcha', 0).';');
+          $this->_doc->addScriptDeclaration('    var jg_use_code = '.$this->params->get('use_easycaptcha', 0).';');
 
           if($this->_config->get('jg_bbcodesupport'))
           {
-            $params->set('bbcode_status', JText::_('COM_JOOMGALLERY_DETAIL_BBCODE_ON'));
+            $this->params->set('bbcode_status', JText::_('COM_JOOMGALLERY_DETAIL_BBCODE_ON'));
           }
           else
           {
-            $params->set('bbcode_status', JText::_('COM_JOOMGALLERY_DETAIL_BBCODE_OFF'));
+            $this->params->set('bbcode_status', JText::_('COM_JOOMGALLERY_DETAIL_BBCODE_OFF'));
           }
 
           if($this->_config->get('jg_smiliesupport'))
           {
-            $params->set('smiley_support', 1);
-            $smileys = JoomHelper::getSmileys();
-            $this->assignRef('smileys', $smileys);
+            $this->params->set('smiley_support', 1);
+            $this->smileys = JoomHelper::getSmileys();
           }
 
           JText::script('COM_JOOMGALLERY_DETAIL_SENDTOFRIEND_ALERT_ENTER_NAME_EMAIL');
@@ -1024,32 +1016,32 @@ class JoomGalleryViewDetail extends JoomGalleryView
            || (!$this->_user->get('username') && $this->_config->get('jg_showcommentsunreg') == 0)
           )
         {
-          $comments = $this->get('Comments');
+          $this->comments = $this->get('Comments');
 
-          if(!$comments)
+          if(!$this->comments)
           {
-            $params->set('no_comments_message', JText::_('COM_JOOMGALLERY_DETAIL_COMMENTS_NOT_EXISTING'));
-            if($params->get('commenting_allowed'))
+            $this->params->set('no_comments_message', JText::_('COM_JOOMGALLERY_DETAIL_COMMENTS_NOT_EXISTING'));
+            if($this->params->get('commenting_allowed'))
             {
-              $params->set('no_comments_message2', JText::_('COM_JOOMGALLERY_DETAIL_COMMENTS_WRITE_FIRST'));
+              $this->params->set('no_comments_message2', JText::_('COM_JOOMGALLERY_DETAIL_COMMENTS_WRITE_FIRST'));
             }
           }
           else
           {
-            $params->set('show_comments', 1);
+            $this->params->set('show_comments', 1);
 
             // Manager logged?
             if(    $this->_user->authorise('core.manage', _JOOM_OPTION))
             {
-              $params->set('manager_logged', 1);
+              $this->params->set('manager_logged', 1);
             }
 
-            foreach($comments as $key => $comment)
+            foreach($this->comments as $key => $comment)
             {
               // Display author name or notice that the author is a guest
               if($comment->userid)
               {
-                $comments[$key]->author = JHTML::_('joomgallery.displayname', $comment->userid, 'comment');
+                $this->comments[$key]->author = JHTML::_('joomgallery.displayname', $comment->userid, 'comment');
               }
               else
               {
@@ -1057,16 +1049,16 @@ class JoomGalleryViewDetail extends JoomGalleryView
                 {
                   if($comment->cmtname != JText::_('COM_JOOMGALLERY_COMMON_GUEST'))
                   {
-                    $comments[$key]->author = JText::sprintf('COM_JOOMGALLERY_DETAIL_COMMENTS_GUEST_NAME', $comment->cmtname);
+                    $this->comments[$key]->author = JText::sprintf('COM_JOOMGALLERY_DETAIL_COMMENTS_GUEST_NAME', $comment->cmtname);
                   }
                   else
                   {
-                    $comments[$key]->author = $comment->cmtname;
+                    $this->comments[$key]->author = $comment->cmtname;
                   }
                 }
                 else
                 {
-                  $comments[$key]->author = JText::_('COM_JOOMGALLERY_COMMON_GUEST');
+                  $this->comments[$key]->author = JText::_('COM_JOOMGALLERY_COMMON_GUEST');
                 }
               }
 
@@ -1085,57 +1077,38 @@ class JoomGalleryViewDetail extends JoomGalleryView
                   $text = str_replace($i, '<img src="'.$sm.'" border="0" alt="'.$i.'" title="'.$i.'" />', $text);
                 }
               }
-              $comments[$key]->text = $text;
+              $this->comments[$key]->text = $text;
             }
-
-            $this->assignRef('comments', $comments);
           }
         }
         else
         {
-          $params->set('no_comments_message', JText::_('COM_JOOMGALLERY_DETAIL_COMMENTS_NOT_FOR_UNREG'));
+          $this->params->set('no_comments_message', JText::_('COM_JOOMGALLERY_DETAIL_COMMENTS_NOT_FOR_UNREG'));
         }
       }
 
       if($this->_config->get('jg_send2friend'))
       {
-        $params->set('show_send2friend_block', 1);
+        $this->params->set('show_send2friend_block', 1);
 
         if($this->_user->get('id'))
         {
-          $params->set('show_send2friend_form', 1);
+          $this->params->set('show_send2friend_form', 1);
         }
         else
         {
-          $params->set('send2friend_message', JText::_('COM_JOOMGALLERY_DETAIL_LOGIN_FIRST'));
+          $this->params->set('send2friend_message', JText::_('COM_JOOMGALLERY_DETAIL_LOGIN_FIRST'));
         }
       }
     }
 
-    $icons        = $this->_mainframe->triggerEvent('onJoomDisplayIcons', array('detail.image', $image));
-    $event->icons = implode('', $icons);
-    $afterDisplay = $this->_mainframe->triggerEvent('onJoomAfterDisplayDetailImage', array($image));
-    $event->afterDisplay = implode('', $afterDisplay);
+    $icons                     = $this->_mainframe->triggerEvent('onJoomDisplayIcons', array('detail.image', $this->image));
+    $this->event->icons        = implode('', $icons);
+    $afterDisplay              = $this->_mainframe->triggerEvent('onJoomAfterDisplayDetailImage', array($this->image));
+    $this->event->afterDisplay = implode('', $afterDisplay);
 
     // Set redirect url used in editor links to redirect back to favourites view after edit/delete
-    $redirect = '&redirect='.base64_encode(JFactory::getURI()->toString());
-
-    $this->assignRef('params',          $params);
-    $this->assignRef('pagination',      $pagination);
-    $this->assignRef('image',           $image);
-    $this->assignRef('images',          $images);
-    $this->assignRef('extra',           $extra);
-    $this->assignRef('slideshow',       $slideshow);
-    $this->assignRef('slider',          $slider);
-    $this->assignRef('toggler',         $toggler);
-    $this->assignRef('pathway',         $pathway);
-    $this->assignRef('modules',         $modules);
-    $this->assignRef('event',           $event);
-    $this->assignRef('backtarget',      $backtarget);
-    $this->assignRef('backtext',        $backtext);
-    $this->assignRef('numberofpics',    $numbers[0]);
-    $this->assignRef('numberofhits',    $numbers[1]);
-    $this->assignRef('redirect',        $redirect);
+    $this->redirect = '&redirect='.base64_encode(JFactory::getURI()->toString());
 
     $this->_doc->addScript($this->_ambit->getScript('detail.js'));
 

--- a/components/com_joomgallery/views/downloadzip/view.html.php
+++ b/components/com_joomgallery/views/downloadzip/view.html.php
@@ -31,7 +31,7 @@ class JoomGalleryViewDownloadzip extends JoomGalleryView
    */
   function display($tpl = null)
   {
-    $params = $this->_mainframe->getParams();
+    $this->params = $this->_mainframe->getParams();
 
     // Breadcrumbs
     if($this->_config->get('jg_completebreadcrumbs'))
@@ -41,38 +41,40 @@ class JoomGalleryViewDownloadzip extends JoomGalleryView
     }
 
     // Header and footer
-    JoomHelper::prepareParams($params);
+    JoomHelper::prepareParams($this->params);
 
-    $pathway  = JText::_('COM_JOOMGALLERY_DOWNLOADZIP_DOWNLOAD');
+    $this->pathway = JText::_('COM_JOOMGALLERY_DOWNLOADZIP_DOWNLOAD');
 
-    $backtarget = JRoute::_('index.php?view=favourites'); //see above
-    $backtext   = JText::_('COM_JOOMGALLERY_DOWNLOADZIP_BACK_TO_FAVOURITES');
+    $this->backtarget = JRoute::_('index.php?view=favourites'); //see above
+    $this->backtext   = JText::_('COM_JOOMGALLERY_DOWNLOADZIP_BACK_TO_FAVOURITES');
 
     // Get number of images and hits in gallery
-    $numbers  = JoomHelper::getNumberOfImgHits();
+    $numbers            = JoomHelper::getNumberOfImgHits();
+    $this->numberofpics = $numbers[0];
+    $this->numberofhits = $numbers[1];
 
     // Load modules at position 'top'
-    $modules['top'] = JoomHelper::getRenderedModules('top');
-    if(count($modules['top']))
+    $this->modules['top'] = JoomHelper::getRenderedModules('top');
+    if(count($this->modules['top']))
     {
-      $params->set('show_top_modules', 1);
+      $this->params->set('show_top_modules', 1);
     }
 
     // Load modules at position 'btm'
-    $modules['btm'] = JoomHelper::getRenderedModules('btm');
-    if(count($modules['btm']))
+    $this->modules['btm'] = JoomHelper::getRenderedModules('btm');
+    if(count($this->modules['btm']))
     {
-      $params->set('show_btm_modules', 1);
+      $this->params->set('show_btm_modules', 1);
     }
 
-    $zipname = $this->_mainframe->getUserState('joom.favourites.zipname');
+    $this->zipname = $this->_mainframe->getUserState('joom.favourites.zipname');
 
-    if(!$zipname || !file_exists(JPath::clean(JPATH_ROOT.'/'.$zipname)))
+    if(!$this->zipname || !file_exists(JPath::clean(JPATH_ROOT.'/'.$this->zipname)))
     {
       $this->_mainframe->redirect(JRoute::_('index.php?view=favourites', false), JText::_('COM_JOOMGALLERY_DOWNLOADZIP_ZIPFILE_NOT_FOUND'), 'error');
     }
 
-    $zipsize = filesize($zipname);
+    $zipsize = filesize($this->zipname);
     if($zipsize < 1000000)
     {
       $zipsize        = round($zipsize, -3) / 1000;
@@ -88,15 +90,7 @@ class JoomGalleryViewDownloadzip extends JoomGalleryView
                                       );
     }
 
-    $this->assignRef('params',          $params);
-    $this->assignRef('zipname',         $zipname);
-    $this->assignRef('zipsize',         $zipsize_string);
-    $this->assignRef('pathway',         $pathway);
-    $this->assignRef('modules',         $modules);
-    $this->assignRef('backtarget',      $backtarget);
-    $this->assignRef('backtext',        $backtext);
-    $this->assignRef('numberofpics',    $numbers[0]);
-    $this->assignRef('numberofhits',    $numbers[1]);
+    $this->zipsize = &$zipsize_string;
 
     parent::display($tpl);
   }

--- a/components/com_joomgallery/views/edit/view.html.php
+++ b/components/com_joomgallery/views/edit/view.html.php
@@ -44,7 +44,7 @@ class JoomGalleryViewEdit extends JoomGalleryView
       $this->_mainframe->redirect(JRoute::_('index.php?view=gallery', false), JText::_('COM_JOOMGALLERY_COMMON_MSG_YOU_ARE_NOT_LOGGED'), 'notice');
     }
 
-    $params = $this->_mainframe->getParams();
+    $this->params = $this->_mainframe->getParams();
 
     // Breadcrumbs
     if($this->_config->get('jg_completebreadcrumbs'))
@@ -55,86 +55,75 @@ class JoomGalleryViewEdit extends JoomGalleryView
     }
 
     // Header and footer
-    JoomHelper::prepareParams($params);
+    JoomHelper::prepareParams($this->params);
 
-    $pathway = null;
+    $this->pathway = null;
     if($this->_config->get('jg_showpathway'))
     {
-      $pathway  = '<a href="'.JRoute::_('index.php?view=userpanel').'">'.JText::_('COM_JOOMGALLERY_COMMON_USER_PANEL').'</a>';
-      $pathway .= ' &raquo; '.JText::_('COM_JOOMGALLERY_EDIT_EDIT_IMAGE');
+      $this->pathway  = '<a href="'.JRoute::_('index.php?view=userpanel').'">'.JText::_('COM_JOOMGALLERY_COMMON_USER_PANEL').'</a>';
+      $this->pathway .= ' &raquo; '.JText::_('COM_JOOMGALLERY_EDIT_EDIT_IMAGE');
     }
 
-    $backtarget = JRoute::_('index.php?view=userpanel'); //see above
-    $backtext   = JText::_('COM_JOOMGALLERY_COMMON_BACK_TO_USER_PANEL');
+    $this->backtarget = JRoute::_('index.php?view=userpanel'); //see above
+    $this->backtext   = JText::_('COM_JOOMGALLERY_COMMON_BACK_TO_USER_PANEL');
 
     // Get number of images and hits in gallery
-    $numbers  = JoomHelper::getNumberOfImgHits();
+    $numbers            = JoomHelper::getNumberOfImgHits();
+    $this->numberofpics = $numbers[0];
+    $this->numberofhits = $numbers[1];
 
     // Load modules at position 'top'
-    $modules['top'] = JoomHelper::getRenderedModules('top');
-    if(count($modules['top']))
+    $this->modules['top'] = JoomHelper::getRenderedModules('top');
+    if(count($this->modules['top']))
     {
-      $params->set('show_top_modules', 1);
+      $this->params->set('show_top_modules', 1);
     }
     // Load modules at position 'btm'
-    $modules['btm'] = JoomHelper::getRenderedModules('btm');
-    if(count($modules['btm']))
+    $this->modules['btm'] = JoomHelper::getRenderedModules('btm');
+    if(count($this->modules['btm']))
     {
-      $params->set('show_btm_modules', 1);
+      $this->params->set('show_btm_modules', 1);
     }
 
     $model = $this->getModel();
-    $array = JRequest::getVar('id',  0, '', 'array');
+    $array = $this->_mainframe->input->get('id', array(0), 'array');
     $model->setId((int)$array[0]);
-    $image = $model->getImage();
+    $this->image = $model->getImage();
 
     // Get the form and fill the fields
-    $form = $this->get('Form');
+    $this->form = $this->get('Form');
 
     // Bind the data to the form
-    $form->bind($image);
+    $this->form->bind($this->image);
 
     // Set some form fields manually
-    $form->setValue('imagelib', null, $image->thumb_url);
+    $this->form->setValue('imagelib', null, $this->image->thumb_url);
 
     // Get limitstart from request to set the correct limitstart (page) in userpanel when
     // leaving edit mode with save or cancel
-    $limitstart = JRequest::getVar('limitstart', null);
-    $slimitstart = ($limitstart != null ? '&limitstart='.(int)$limitstart : '');
+    $limitstart = $this->_mainframe->input->get('limitstart', null);
+    $this->slimitstart = ($limitstart != null ? '&limitstart='.(int)$limitstart : '');
 
     // Get redirect page, if any given by request
-    $redirect     = JRequest::getVar('redirect', null);
-    $redirecturl  = '';
-    if($redirect === null)
+    $this->redirect     = $this->_mainframe->input->getBase64('redirect');
+    $this->redirecturl  = '';
+    if($this->redirect === null)
     {
-      $redirect = '';
+      $this->redirect = '';
     }
     else
     {
-      $redirecturl = base64_decode($redirect);
-      if(!JURI::isInternal($redirecturl))
+      $this->redirecturl = base64_decode($this->redirect);
+      if(!JURI::isInternal($this->redirecturl))
       {
-        $redirecturl = '';
-        $redirect    = '';
+        $this->redirecturl = '';
+        $this->redirect    = '';
       }
       else
       {
-        $redirect = '&redirect='.$redirect;
+        $this->redirect = '&redirect='.$this->redirect;
       }
     }
-
-    $this->assignRef('params',          $params);
-    $this->assignRef('form',            $form);
-    $this->assignRef('image',           $image);
-    $this->assignRef('pathway',         $pathway);
-    $this->assignRef('modules',         $modules);
-    $this->assignRef('backtarget',      $backtarget);
-    $this->assignRef('backtext',        $backtext);
-    $this->assignRef('numberofpics',    $numbers[0]);
-    $this->assignRef('numberofhits',    $numbers[1]);
-    $this->assignRef('slimitstart',     $slimitstart);
-    $this->assignRef('redirect',        $redirect);
-    $this->assignRef('redirecturl',     $redirecturl);
 
     parent::display($tpl);
   }

--- a/components/com_joomgallery/views/favourites/view.html.php
+++ b/components/com_joomgallery/views/favourites/view.html.php
@@ -38,36 +38,39 @@ class JoomGalleryViewFavourites extends JoomGalleryView
       $breadcrumbs->addItem($this->output('MY'));
     }
 
-    $params = $this->_mainframe->getParams();
+    $this->params = $this->_mainframe->getParams();
 
     // Header and footer
-    JoomHelper::prepareParams($params);
+    JoomHelper::prepareParams($this->params);
 
-    $pathway = $this->output('MY');
+    $this->pathway = $this->output('MY');
 
-    $backtarget = JRoute::_('index.php?view=gallery'); //see above
-    $backtext   = JText::_('COM_JOOMGALLERY_COMMON_BACK_TO_GALLERY');
+    $this->backtarget = JRoute::_('index.php?view=gallery'); //see above
+    $this->backtext   = JText::_('COM_JOOMGALLERY_COMMON_BACK_TO_GALLERY');
 
     // Get number of images and hits in gallery
     $numbers = JoomHelper::getNumberOfImgHits();
+    $this->numberofpics = $numbers[0];
+    $this->numberofhits = $numbers[1];
+
 
     // Load modules at position 'top'
-    $modules['top'] = JoomHelper::getRenderedModules('top');
-    if(count($modules['top']))
+    $this->modules['top'] = JoomHelper::getRenderedModules('top');
+    if(count($this->modules['top']))
     {
-      $params->set('show_top_modules', 1);
+      $this->params->set('show_top_modules', 1);
     }
     // Load modules at position 'btm'
-    $modules['btm'] = JoomHelper::getRenderedModules('btm');
-    if(count($modules['btm']))
+    $this->modules['btm'] = JoomHelper::getRenderedModules('btm');
+    if(count($this->modules['btm']))
     {
-      $params->set('show_btm_modules', 1);
+      $this->params->set('show_btm_modules', 1);
     }
 
-    $state = $this->get('State');
-    $rows = $this->get('Favourites');
+    $this->state = $this->get('State');
+    $this->rows = $this->get('Favourites');
 
-    foreach($rows as $key => $row)
+    foreach($this->rows as $key => $row)
     {
       $row->link = JHTML::_('joomgallery.openimage', $this->_config->get('jg_detailpic_open'), $row);
 
@@ -86,12 +89,12 @@ class JoomGalleryViewFavourites extends JoomGalleryView
       // if a box is activated
       if(!is_numeric($this->_config->get('jg_detailpic_open')) || $this->_config->get('jg_detailpic_open') > 1)
       {
-        $rows[$key]->atagtitle = JHTML::_('joomgallery.getTitleforATag', $row);
+        $this->rows[$key]->atagtitle = JHTML::_('joomgallery.getTitleforATag', $row);
       }
       else
       {
         // Set the imgtitle by default
-        $rows[$key]->atagtitle = 'title="'.$row->imgtitle.'"';
+        $this->rows[$key]->atagtitle = 'title="'.$row->imgtitle.'"';
       }
 
       if($this->_config->get('jg_showauthor'))
@@ -143,32 +146,21 @@ class JoomGalleryViewFavourites extends JoomGalleryView
     {
       if($this->_user->get('id') || $this->_config->get('jg_download_unreg'))
       {
-        $params->set('show_download_icon', 1);
+        $this->params->set('show_download_icon', 1);
       }
       else
       {
         if($this->_config->get('jg_download_hint'))
         {
-          $params->set('show_download_icon', -1);
+          $this->params->set('show_download_icon', -1);
         }
       }
     }
 
     // Set redirect url used in editor links to redirect back to favourites view after edit/delete
-    $redirect = '&redirect='.base64_encode(JFactory::getURI()->toString());
+    $this->redirect = '&redirect='.base64_encode(JFactory::getURI()->toString());
 
-    $this->assignRef('params',          $params);
-    $this->assignRef('rows',            $rows);
-    $this->assignRef('state',           $state);
-    $this->assignRef('pathway',         $pathway);
-    $this->assignRef('modules',         $modules);
-    $this->assignRef('backtarget',      $backtarget);
-    $this->assignRef('backtext',        $backtext);
-    $this->assignRef('numberofpics',    $numbers[0]);
-    $this->assignRef('numberofhits',    $numbers[1]);
-    $this->assignRef('redirect',        $redirect);
-
-    $layout = JRequest::getCmd('layout');
+    $layout = $this->_mainframe->input->getCmd('layout');
     if(!$layout && $this->get('Layout'))
     {
       $this->setLayout('list');

--- a/components/com_joomgallery/views/image/view.raw.php
+++ b/components/com_joomgallery/views/image/view.raw.php
@@ -32,12 +32,12 @@ class JoomGalleryViewImage extends JoomGalleryView
   {
     jimport('joomla.filesystem.file');
 
-    $type     = JRequest::getWord('type', 'thumb');
-    $download = JRequest::getCmd('download');
+    $type     = $this->_mainframe->input->getWord('type', 'thumb');
+    $download = $this->_mainframe->input->getCmd('download');
 
     $crop_image = false;
-    $cropwidth  = JRequest::getInt('width');
-    $cropheight = JRequest::getInt('height');
+    $cropwidth  = $this->_mainframe->input->getInt('width');
+    $cropheight = $this->_mainframe->input->getInt('height');
     if($cropwidth && $cropheight)
     {
       $crop_image = true;
@@ -45,7 +45,7 @@ class JoomGalleryViewImage extends JoomGalleryView
 
     $model = $this->getModel();
 
-    if(!$image = $model->getImage(JRequest::getInt('id')))
+    if(!$image = $model->getImage($this->_mainframe->input->getInt('id')))
     {
       return $this->displayError($model->getError());
     }
@@ -205,9 +205,9 @@ class JoomGalleryViewImage extends JoomGalleryView
       $img_resource = null;
       if($crop_image)
       {
-        $croppos  = JRequest::getInt('pos');
-        $offsetx  = JRequest::getInt('x');
-        $offsety  = JRequest::getInt('y');
+        $croppos  = $this->_mainframe->input->getInt('pos');
+        $offsetx  = $this->_mainframe->input->getInt('x');
+        $offsety  = $this->_mainframe->input->getInt('y');
         $img_resource = $model->cropImage($img, $cropwidth, $cropheight, $croppos, $offsetx, $offsety);
       }
 
@@ -234,7 +234,7 @@ class JoomGalleryViewImage extends JoomGalleryView
             imagepng($img_resource);
             break;
           case 'image/jpeg':
-            $quali = JRequest::getInt('quali', 95);
+            $quali = $this->_mainframe->input->getInt('quali', 95);
             imagejpeg($img_resource, null, $quali);
             break;
           default:
@@ -261,9 +261,9 @@ class JoomGalleryViewImage extends JoomGalleryView
   {
     $this->_doc->setMimeEncoding('image/jpeg');
 
-    $type   = JRequest::getWord('type', 'thumb');
-    $width  = JRequest::getInt('width');
-    $height = JRequest::getInt('height');
+    $type   = $this->_mainframe->input->getWord('type', 'thumb');
+    $width  = $this->_mainframe->input->getInt('width');
+    $height = $this->_mainframe->input->getInt('height');
 
     if(!$width || !$height)
     {

--- a/components/com_joomgallery/views/report/tmpl/default.php
+++ b/components/com_joomgallery/views/report/tmpl/default.php
@@ -21,7 +21,7 @@ $this->_doc->addStyleSheet($this->_ambit->getStyleSheet('joomgallery.css')); ?>
       </div>
       <div>
         <?php echo implode('', $this->_mainframe->triggerEvent('onJoomGetCaptcha', array('report'))); ?>
-        <input type="hidden" name="id" value="<?php echo JRequest::getInt('id'); ?>" />
+        <input type="hidden" name="id" value="<?php echo $this->_mainframe->input->getInt('id'); ?>" />
         <input type="hidden" name="task" value="report.send" />
         <input type="hidden" name="tmpl" value="component" />
       </div>

--- a/components/com_joomgallery/views/search/view.html.php
+++ b/components/com_joomgallery/views/search/view.html.php
@@ -30,7 +30,7 @@ class JoomGalleryViewSearch extends JoomGalleryView
    */
   public function display($tpl = null)
   {
-    $params           = $this->_mainframe->getParams();
+    $this->params           = $this->_mainframe->getParams();
 
     // Breadcrumbs
     if($this->_config->get('jg_completebreadcrumbs'))
@@ -40,39 +40,41 @@ class JoomGalleryViewSearch extends JoomGalleryView
     }
 
     // Header and footer
-    JoomHelper::prepareParams($params);
+    JoomHelper::prepareParams($this->params);
 
-    $pathway = JText::_('COM_JOOMGALLERY_SEARCH_RESULTS');
+    $this->pathway = JText::_('COM_JOOMGALLERY_SEARCH_RESULTS');
 
-    $backtarget = JRoute::_('index.php?view=gallery'); //see above
-    $backtext   = JText::_('COM_JOOMGALLERY_COMMON_BACK_TO_GALLERY');
+    $this->backtarget = JRoute::_('index.php?view=gallery'); //see above
+    $this->backtext   = JText::_('COM_JOOMGALLERY_COMMON_BACK_TO_GALLERY');
 
     // Get number of images and hits in gallery
-    $numbers  = JoomHelper::getNumberOfImgHits();
+    $numbers            = JoomHelper::getNumberOfImgHits();
+    $this->numberofpics = $numbers[0];
+    $this->numberofhits = $numbers[1];
 
     // Load modules at position 'top'
-    $modules['top'] = JoomHelper::getRenderedModules('top');
-    if(count($modules['top']))
+    $this->modules['top'] = JoomHelper::getRenderedModules('top');
+    if(count($this->modules['top']))
     {
-      $params->set('show_top_modules', 1);
+      $this->params->set('show_top_modules', 1);
     }
     // Load modules at position 'btm'
-    $modules['btm'] = JoomHelper::getRenderedModules('btm');
-    if(count($modules['btm']))
+    $this->modules['btm'] = JoomHelper::getRenderedModules('btm');
+    if(count($this->modules['btm']))
     {
-      $params->set('show_btm_modules', 1);
+      $this->params->set('show_btm_modules', 1);
     }
 
-    $sstring  = trim(JRequest::getVar('sstring'));
-    $rows     = array();
-    if(!empty($sstring))
+    $this->sstring = trim($this->_mainframe->input->get('sstring'));
+    $this->rows    = array();
+    if(!empty($this->sstring))
     {
-      $rows     = $this->get('SearchResults');
+      $this->rows  = $this->get('SearchResults');
     }
 
-    foreach($rows as $key => $row)
+    foreach($this->rows as $key => $row)
     {
-      $rows[$key]->link = JHTML::_('joomgallery.openimage', $this->_config->get('jg_detailpic_open'), $row);
+      $this->rows[$key]->link = JHTML::_('joomgallery.openimage', $this->_config->get('jg_detailpic_open'), $row);
 
       $cropx    = null;
       $cropy    = null;
@@ -89,54 +91,54 @@ class JoomGalleryViewSearch extends JoomGalleryView
       // if a box is activated
       if(!is_numeric($this->_config->get('jg_detailpic_open')) || $this->_config->get('jg_detailpic_open') > 1)
       {
-        $rows[$key]->atagtitle = JHTML::_('joomgallery.getTitleforATag', $row);
+        $this->rows[$key]->atagtitle = JHTML::_('joomgallery.getTitleforATag', $row);
       }
       else
       {
         // Set the imgtitle by default
-        $rows[$key]->atagtitle = 'title="'.$row->imgtitle.'"';
+        $this->rows[$key]->atagtitle = 'title="'.$row->imgtitle.'"';
       }
 
       if($this->_config->get('jg_showauthor'))
       {
         if($row->imgauthor)
         {
-          $rows[$key]->authorowner = $row->imgauthor;
+          $this->rows[$key]->authorowner = $row->imgauthor;
         }
         else
         {
           if($this->_config->get('jg_showowner'))
           {
-            $rows[$key]->authorowner = JHTML::_('joomgallery.displayname', $row->owner);
+            $this->rows[$key]->authorowner = JHTML::_('joomgallery.displayname', $row->owner);
           }
           else
           {
-            $rows[$key]->authorowner = JText::_('COM_JOOMGALLERY_COMMON_NO_DATA');
+            $this->rows[$key]->authorowner = JText::_('COM_JOOMGALLERY_COMMON_NO_DATA');
           }
         }
       }
 
       // Show editor links for that image
-      $rows[$key]->show_edit_icon   = false;
-      $rows[$key]->show_delete_icon = false;
+      $this->rows[$key]->show_edit_icon   = false;
+      $this->rows[$key]->show_delete_icon = false;
       if(   $this->_config->get('jg_showsearcheditorlinks') == 1
          && $this->_config->get('jg_userspace') == 1
         )
       {
-        if( (   $this->_user->authorise('core.edit', _JOOM_OPTION.'.image.'.$rows[$key]->id)
-            ||  (   $this->_user->authorise('core.edit.own', _JOOM_OPTION.'.image.'.$rows[$key]->id)
-                &&  $rows[$key]->owner
-                &&  $rows[$key]->owner == $this->_user->get('id')
+        if( (   $this->_user->authorise('core.edit', _JOOM_OPTION.'.image.'.$this->rows[$key]->id)
+            ||  (   $this->_user->authorise('core.edit.own', _JOOM_OPTION.'.image.'.$this->rows[$key]->id)
+                &&  $this->rows[$key]->owner
+                &&  $this->rows[$key]->owner == $this->_user->get('id')
                 )
             )
         )
         {
-          $rows[$key]->show_edit_icon = true;
+          $this->rows[$key]->show_edit_icon = true;
         }
 
-        if($this->_user->authorise('core.delete', _JOOM_OPTION.'.image.'.$rows[$key]->id))
+        if($this->_user->authorise('core.delete', _JOOM_OPTION.'.image.'.$this->rows[$key]->id))
         {
-          $rows[$key]->show_delete_icon = true;
+          $this->rows[$key]->show_delete_icon = true;
         }
       }
     }
@@ -146,19 +148,19 @@ class JoomGalleryViewSearch extends JoomGalleryView
     {
       if($this->_user->get('id') || $this->_config->get('jg_download_unreg'))
       {
-        $params->set('show_download_icon', 1);
+        $this->params->set('show_download_icon', 1);
       }
       else
       {
         if($this->_config->get('jg_download_hint'))
         {
-          $params->set('show_download_icon', -1);
+          $this->params->set('show_download_icon', -1);
         }
       }
     }
 
     // Favourites icon
-    if(!$params->get('disable_global_info') && $this->_config->get('jg_favourites') && $this->_config->get('jg_showsearchfavourite'))
+    if(!$this->params->get('disable_global_info') && $this->_config->get('jg_favourites') && $this->_config->get('jg_showsearchfavourite'))
     {
       if(   $this->_user->get('id')
          || ($this->_config->get('jg_usefavouritesforpubliczip') == 1 && !$this->_user->get('id'))
@@ -168,11 +170,11 @@ class JoomGalleryViewSearch extends JoomGalleryView
            || ($this->_config->get('jg_usefavouritesforpubliczip') && !$this->_user->get('id'))
           )
         {
-          $params->set('show_favourites_icon', 2);
+          $this->params->set('show_favourites_icon', 2);
         }
         else
         {
-          $params->set('show_favourites_icon', 1);
+          $this->params->set('show_favourites_icon', 1);
         }
       }
       else
@@ -181,11 +183,11 @@ class JoomGalleryViewSearch extends JoomGalleryView
         {
           if($this->_config->get('jg_usefavouritesforzip'))
           {
-            $params->set('show_favourites_icon', -2);
+            $this->params->set('show_favourites_icon', -2);
           }
           else
           {
-            $params->set('show_favourites_icon', -1);
+            $this->params->set('show_favourites_icon', -1);
           }
         }
       }
@@ -196,7 +198,7 @@ class JoomGalleryViewSearch extends JoomGalleryView
     {
       if($this->_user->get('id') || $this->_config->get('jg_report_unreg'))
       {
-        $params->set('show_report_icon', 1);
+        $this->params->set('show_report_icon', 1);
 
         JHTML::_('behavior.modal');
       }
@@ -204,25 +206,14 @@ class JoomGalleryViewSearch extends JoomGalleryView
       {
         if($this->_config->get('jg_report_hint'))
         {
-          $params->set('show_report_icon', -1);
+          $this->params->set('show_report_icon', -1);
         }
       }
     }
 
     $uri = JFactory::getURI();
-    $uri->setVar('sstring', $sstring);
-    $redirect = '&redirect='.base64_encode($uri->toString());
-
-    $this->assignRef('params',          $params);
-    $this->assignRef('rows',            $rows);
-    $this->assignRef('sstring',         $sstring);
-    $this->assignRef('pathway',         $pathway);
-    $this->assignRef('modules',         $modules);
-    $this->assignRef('backtarget',      $backtarget);
-    $this->assignRef('backtext',        $backtext);
-    $this->assignRef('numberofpics',    $numbers[0]);
-    $this->assignRef('numberofhits',    $numbers[1]);
-    $this->assignRef('redirect',        $redirect);
+    $uri->setVar('sstring', $this->sstring);
+    $this->redirect = '&redirect='.base64_encode($uri->toString());
 
     parent::display($tpl);
   }

--- a/components/com_joomgallery/views/toplist/view.html.php
+++ b/components/com_joomgallery/views/toplist/view.html.php
@@ -30,62 +30,64 @@ class JoomGalleryViewToplist extends JoomGalleryView
    */
   public function display($tpl = null)
   {
-    $params = $this->_mainframe->getParams();
+    $this->params = $this->_mainframe->getParams();
 
     // Header and footer
-    JoomHelper::prepareParams($params);
+    JoomHelper::prepareParams($this->params);
 
-    $backtarget = JRoute::_('index.php?view=gallery'); //see above
-    $backtext   = JText::_('COM_JOOMGALLERY_COMMON_BACK_TO_GALLERY');
+    $this->backtarget = JRoute::_('index.php?view=gallery'); //see above
+    $this->backtext   = JText::_('COM_JOOMGALLERY_COMMON_BACK_TO_GALLERY');
 
     // Get number of images and hits in gallery
-    $numbers  = JoomHelper::getNumberOfImgHits();
+    $numbers            = JoomHelper::getNumberOfImgHits();
+    $this->numberofpics = $numbers[0];
+    $this->numberofhits = $numbers[1];
 
     // Load modules at position 'top'
-    $modules['top'] = JoomHelper::getRenderedModules('top');
-    if(count($modules['top']))
+    $this->modules['top'] = JoomHelper::getRenderedModules('top');
+    if(count($this->modules['top']))
     {
-      $params->set('show_top_modules', 1);
+      $this->params->set('show_top_modules', 1);
     }
     // Load modules at position 'btm'
-    $modules['btm'] = JoomHelper::getRenderedModules('btm');
-    if(count($modules['btm']))
+    $this->modules['btm'] = JoomHelper::getRenderedModules('btm');
+    if(count($this->modules['btm']))
     {
-      $params->set('show_btm_modules', 1);
+      $this->params->set('show_btm_modules', 1);
     }
 
-    $type = JRequest::getCmd('type');
-    switch($type)
+    $this->type = $this->_mainframe->input->getCmd('type');
+    switch($this->type)
     {
       case 'lastcommented':
-        $rows     = $this->get('LastCommented');
-        $title    = JText::sprintf('COM_JOOMGALLERY_TOPLIST_LAST_COMMENTED_IMAGE', $this->_config->get('jg_toplist'));
-        $pathway  = $title;
+        $this->rows    = $this->get('LastCommented');
+        $this->title   = JText::sprintf('COM_JOOMGALLERY_TOPLIST_LAST_COMMENTED_IMAGE', $this->_config->get('jg_toplist'));
+        $this->pathway = $this->title;
         break;
       case 'lastadded':
-        $rows     = $this->get('LastAdded');
-        $title    = JText::sprintf('COM_JOOMGALLERY_TOPLIST_LAST_ADDED_IMAGE', $this->_config->get('jg_toplist'));
-        $pathway  = $title;
+        $this->rows    = $this->get('LastAdded');
+        $this->title   = JText::sprintf('COM_JOOMGALLERY_TOPLIST_LAST_ADDED_IMAGE', $this->_config->get('jg_toplist'));
+        $this->pathway = $this->title;
         break;
       case 'toprated':
-        $rows     = $this->get('TopRated');
-        $title    = JText::sprintf('COM_JOOMGALLERY_TOPLIST_BEST_RATED_IMAGE', $this->_config->get('jg_toplist'));
-        $pathway  = $title;
+        $this->rows    = $this->get('TopRated');
+        $this->title   = JText::sprintf('COM_JOOMGALLERY_TOPLIST_BEST_RATED_IMAGE', $this->_config->get('jg_toplist'));
+        $this->pathway = $this->title;
         break;
       default:
-        $rows     = $this->get('MostViewed');
-        $title    = JText::sprintf('COM_JOOMGALLERY_TOPLIST_MOST_VIEWED_IMAGE', $this->_config->get('jg_toplist'));
-        $pathway  = $title;
+        $this->rows    = $this->get('MostViewed');
+        $this->title   = JText::sprintf('COM_JOOMGALLERY_TOPLIST_MOST_VIEWED_IMAGE', $this->_config->get('jg_toplist'));
+        $this->pathway = $this->title;
         break;
     }
 
     // Check whether this is the active menu item. This is a
     // special case in addition to code in constructor of parent class
     // because here we have to check the toplist type, too.
-    if($type == 'lastcommented' || $type == 'lastadded' || $type == 'toprated')
+    if($this->type == 'lastcommented' || $this->type == 'lastadded' || $this->type == 'toprated')
     {
       $active = $this->_mainframe->getMenu()->getActive();
-      if(!$active || strpos($active->link, '&type='.$type) === false)
+      if(!$active || strpos($active->link, '&type='.$this->type) === false)
       {
         // Get the default layout from the configuration
         if($layout = $this->_config->get('jg_alternative_layout'))
@@ -99,18 +101,18 @@ class JoomGalleryViewToplist extends JoomGalleryView
     if($this->_config->get('jg_completebreadcrumbs'))
     {
       $breadcrumbs  = $this->_mainframe->getPathway();
-      $breadcrumbs->addItem($title);
+      $breadcrumbs->addItem($this->title);
     }
 
     // Check whether the (comments) data rows where delivered by a plugin
-    if(isset($rows[0]->delivered_by_plugin) && $rows[0]->delivered_by_plugin)
+    if(isset($this->rows[0]->delivered_by_plugin) && $this->rows[0]->delivered_by_plugin)
     {
-      $params->set('delivered_by_plugin', 1);
+      $this->params->set('delivered_by_plugin', 1);
     }
 
-    foreach($rows as $key => $row)
+    foreach($this->rows as $key => $row)
     {
-      $rows[$key]->link = JHTML::_('joomgallery.openimage', $this->_config->get('jg_detailpic_open'), $row);
+      $this->rows[$key]->link = JHTML::_('joomgallery.openimage', $this->_config->get('jg_detailpic_open'), $row);
 
       $cropx    = null;
       $cropy    = null;
@@ -121,46 +123,46 @@ class JoomGalleryViewToplist extends JoomGalleryView
         $cropy    = $this->_config->get('jg_dyncropheight');
         $croppos  = $this->_config->get('jg_dyncropposition');
       }
-      $rows[$key]->thumb_src = $this->_ambit->getImg('thumb_url', $row, null, 0, true, $cropx, $cropy, $croppos);
+      $this->rows[$key]->thumb_src = $this->_ambit->getImg('thumb_url', $row, null, 0, true, $cropx, $cropy, $croppos);
 
       // Set the title attribute in a tag with title and/or description of image
       // if a box is activated
       if(!is_numeric($this->_config->get('jg_detailpic_open')) || $this->_config->get('jg_detailpic_open') > 1)
       {
-        $rows[$key]->atagtitle = JHTML::_('joomgallery.getTitleforATag', $row);
+        $this->rows[$key]->atagtitle = JHTML::_('joomgallery.getTitleforATag', $row);
       }
       else
       {
         // Set the imgtitle by default
-        $rows[$key]->atagtitle = 'title="'.$row->imgtitle.'"';
+        $this->rows[$key]->atagtitle = 'title="'.$row->imgtitle.'"';
       }
 
       if($this->_config->get('jg_showauthor'))
       {
         if($row->imgauthor)
         {
-          $rows[$key]->authorowner = $row->imgauthor;
+          $this->rows[$key]->authorowner = $row->imgauthor;
         }
         else
         {
           if($this->_config->get('jg_showowner'))
           {
-            $rows[$key]->authorowner = JHTML::_('joomgallery.displayname', $row->owner);
+            $this->rows[$key]->authorowner = JHTML::_('joomgallery.displayname', $row->owner);
           }
           else
           {
-            $rows[$key]->authorowner = JText::_('COM_JOOMGALLERY_COMMON_NO_DATA');
+            $this->rows[$key]->authorowner = JText::_('COM_JOOMGALLERY_COMMON_NO_DATA');
           }
         }
       }
 
-      if(!$params->get('delivered_by_plugin'))
+      if(!$this->params->get('delivered_by_plugin'))
       {
-        if($type == 'lastcommented' && $this->_config->get('jg_showthiscomment'))
+        if($this->type == 'lastcommented' && $this->_config->get('jg_showthiscomment'))
         {
           if($row->userid)
           {
-            $rows[$key]->cmtname = JHTML::_('joomgallery.displayname', $row->userid, false);
+            $this->rows[$key]->cmtname = JHTML::_('joomgallery.displayname', $row->userid, false);
           }
 
           $cmttext = $row->cmttext;
@@ -179,31 +181,31 @@ class JoomGalleryViewToplist extends JoomGalleryView
           }
           $cmttext = stripslashes($cmttext);
 
-          $rows[$key]->processed_cmttext = $cmttext;
+          $this->rows[$key]->processed_cmttext = $cmttext;
         }
       }
 
       // Show editor links for that image
-      $rows[$key]->show_edit_icon   = false;
-      $rows[$key]->show_delete_icon = false;
+      $this->rows[$key]->show_edit_icon   = false;
+      $this->rows[$key]->show_delete_icon = false;
       if(   $this->_config->get('jg_showtoplisteditorlinks') == 1
          && $this->_config->get('jg_userspace') == 1
         )
       {
-        if( (   $this->_user->authorise('core.edit', _JOOM_OPTION.'.image.'.$rows[$key]->id)
-            ||  (   $this->_user->authorise('core.edit.own', _JOOM_OPTION.'.image.'.$rows[$key]->id)
-                &&  $rows[$key]->owner
-                &&  $rows[$key]->owner == $this->_user->get('id')
+        if( (   $this->_user->authorise('core.edit', _JOOM_OPTION.'.image.'.$this->rows[$key]->id)
+            ||  (   $this->_user->authorise('core.edit.own', _JOOM_OPTION.'.image.'.$this->rows[$key]->id)
+                &&  $this->rows[$key]->owner
+                &&  $this->rows[$key]->owner == $this->_user->get('id')
                 )
             )
         )
         {
-          $rows[$key]->show_edit_icon = true;
+          $this->rows[$key]->show_edit_icon = true;
         }
 
-        if($this->_user->authorise('core.delete', _JOOM_OPTION.'.image.'.$rows[$key]->id))
+        if($this->_user->authorise('core.delete', _JOOM_OPTION.'.image.'.$this->rows[$key]->id))
         {
-          $rows[$key]->show_delete_icon = true;
+          $this->rows[$key]->show_delete_icon = true;
         }
       }
     }
@@ -213,19 +215,19 @@ class JoomGalleryViewToplist extends JoomGalleryView
     {
       if($this->_user->get('id') || $this->_config->get('jg_download_unreg'))
       {
-        $params->set('show_download_icon', 1);
+        $this->params->set('show_download_icon', 1);
       }
       else
       {
         if($this->_config->get('jg_download_hint'))
         {
-          $params->set('show_download_icon', -1);
+          $this->params->set('show_download_icon', -1);
         }
       }
     }
 
     // Favourites icon
-    if(!$params->get('disable_global_info') && $this->_config->get('jg_favourites') && $this->_config->get('jg_showtoplistfavourite'))
+    if(!$this->params->get('disable_global_info') && $this->_config->get('jg_favourites') && $this->_config->get('jg_showtoplistfavourite'))
     {
       if(   $this->_user->get('id')
          || ($this->_config->get('jg_usefavouritesforpubliczip') == 1 && !$this->_user->get('id'))
@@ -235,11 +237,11 @@ class JoomGalleryViewToplist extends JoomGalleryView
            || ($this->_config->get('jg_usefavouritesforpubliczip') && !$this->_user->get('id'))
           )
         {
-          $params->set('show_favourites_icon', 2);
+          $this->params->set('show_favourites_icon', 2);
         }
         else
         {
-          $params->set('show_favourites_icon', 1);
+          $this->params->set('show_favourites_icon', 1);
         }
       }
       else
@@ -248,11 +250,11 @@ class JoomGalleryViewToplist extends JoomGalleryView
         {
           if($this->_config->get('jg_usefavouritesforzip'))
           {
-            $params->set('show_favourites_icon', -2);
+            $this->params->set('show_favourites_icon', -2);
           }
           else
           {
-            $params->set('show_favourites_icon', -1);
+            $this->params->set('show_favourites_icon', -1);
           }
         }
       }
@@ -263,7 +265,7 @@ class JoomGalleryViewToplist extends JoomGalleryView
     {
       if($this->_user->get('id') || $this->_config->get('jg_report_unreg'))
       {
-        $params->set('show_report_icon', 1);
+        $this->params->set('show_report_icon', 1);
 
         JHTML::_('behavior.modal');
       }
@@ -271,25 +273,13 @@ class JoomGalleryViewToplist extends JoomGalleryView
       {
         if($this->_config->get('jg_report_hint'))
         {
-          $params->set('show_report_icon', -1);
+          $this->params->set('show_report_icon', -1);
         }
       }
     }
 
     // Set redirect url used in editor links to redirect back to favourites view after edit/delete
-    $redirect = '&redirect='.base64_encode(JFactory::getURI()->toString());
-
-    $this->assignRef('params',          $params);
-    $this->assignRef('rows',            $rows);
-    $this->assignRef('title',           $title);
-    $this->assignRef('type',            $type);
-    $this->assignRef('pathway',         $pathway);
-    $this->assignRef('modules',         $modules);
-    $this->assignRef('backtarget',      $backtarget);
-    $this->assignRef('backtext',        $backtext);
-    $this->assignRef('numberofpics',    $numbers[0]);
-    $this->assignRef('numberofhits',    $numbers[1]);
-    $this->assignRef('redirect',        $redirect);
+    $this->redirect = '&redirect='.base64_encode(JFactory::getURI()->toString());
 
     parent::display($tpl);
   }

--- a/components/com_joomgallery/views/upload/view.html.php
+++ b/components/com_joomgallery/views/upload/view.html.php
@@ -48,7 +48,7 @@ class JoomGalleryViewUpload extends JoomGalleryView
       $this->_mainframe->redirect(JRoute::_('index.php?view=userpanel', false), JText::_('COM_JOOMGALLERY_COMMON_MSG_YOU_ARE_NOT_ALLOWED_TO_UPLOAD'), 'notice');
     }
 
-    $params = $this->_mainframe->getParams();
+    $this->params = $this->_mainframe->getParams();
 
     // Breadcrumbs
     if($this->_config->get('jg_completebreadcrumbs'))
@@ -59,62 +59,53 @@ class JoomGalleryViewUpload extends JoomGalleryView
     }
 
     // Header and footer
-    JoomHelper::prepareParams($params);
+    JoomHelper::prepareParams($this->params);
 
-    $pathway = null;
+    $this->pathway = null;
     if($this->_config->get('jg_showpathway'))
     {
-      $pathway  = '<a href="'.JRoute::_('index.php?view=userpanel').'">'.JText::_('COM_JOOMGALLERY_COMMON_USER_PANEL').'</a>';
-      $pathway .= ' &raquo; '.JText::_('COM_JOOMGALLERY_COMMON_UPLOAD_NEW_IMAGE');
+      $this->pathway  = '<a href="'.JRoute::_('index.php?view=userpanel').'">'.JText::_('COM_JOOMGALLERY_COMMON_USER_PANEL').'</a>';
+      $this->pathway .= ' &raquo; '.JText::_('COM_JOOMGALLERY_COMMON_UPLOAD_NEW_IMAGE');
     }
 
-    $backtarget = JRoute::_('index.php?view=gallery');
-    $backtext   = JText::_('COM_JOOMGALLERY_COMMON_BACK_TO_GALLERY');
+    $this->backtarget = JRoute::_('index.php?view=gallery');
+    $this->backtext   = JText::_('COM_JOOMGALLERY_COMMON_BACK_TO_GALLERY');
 
     // Get number of images and hits in gallery
-    $numbers  = JoomHelper::getNumberOfImgHits();
+    $numbers = JoomHelper::getNumberOfImgHits();
+    $this->numberofpics = $numbers[0];
+    $this->numberofhits = $numbers[1];
 
     // Load modules at position 'top'
-    $modules['top'] = JoomHelper::getRenderedModules('top');
-    if(count($modules['top']))
+    $this->modules['top'] = JoomHelper::getRenderedModules('top');
+    if(count($this->modules['top']))
     {
-      $params->set('show_top_modules', 1);
+      $this->params->set('show_top_modules', 1);
     }
     // Load modules at position 'btm'
-    $modules['btm'] = JoomHelper::getRenderedModules('btm');
-    if(count($modules['btm']))
+    $this->modules['btm'] = JoomHelper::getRenderedModules('btm');
+    if(count($this->modules['btm']))
     {
-      $params->set('show_btm_modules', 1);
+      $this->params->set('show_btm_modules', 1);
     }
 
-    $count = $this->get('ImageNumber');
+    $this->count = $this->get('ImageNumber');
 
-    if($count >= $this->_config->get('jg_maxuserimage'))
+    if($this->count >= $this->_config->get('jg_maxuserimage'))
     {
       $timespan = $this->_config->get('jg_maxuserimage_timespan');
       $msg = JText::sprintf('COM_JOOMGALLERY_UPLOAD_OUTPUT_MAY_ADD_MAX_OF', $this->_config->get('jg_maxuserimage'), $timespan > 0 ? JText::plural('COM_JOOMGALLERY_UPLOAD_NEW_IMAGE_MAXCOUNT_TIMESPAN', $timespan) : '');
       $this->_mainframe->redirect(JRoute::_('index.php?view=userpanel', false), $msg, 'notice');
     }
 
-    $inputcounter   = $this->_config->get('jg_maxuserimage') - $count;
-    $remainder      = $inputcounter;
-    if($inputcounter > $this->_config->get('jg_maxuploadfields'))
+    $this->inputcounter   = $this->_config->get('jg_maxuserimage') - $this->count;
+    $this->remainder      = $this->inputcounter;
+    if($this->inputcounter > $this->_config->get('jg_maxuploadfields'))
     {
-      $inputcounter = $this->_config->get('jg_maxuploadfields');
+      $this->inputcounter = $this->_config->get('jg_maxuploadfields');
     }
 
-    $this->assignRef('count',         $count);
-    $this->assignRef('remainder',     $remainder);
-    $this->assignRef('inputcounter',  $inputcounter);
-    $this->_doc->addScriptDeclaration('    var jg_inputcounter = '.$inputcounter.';');
-
-    $this->assignRef('params',          $params);
-    $this->assignRef('pathway',         $pathway);
-    $this->assignRef('modules',         $modules);
-    $this->assignRef('backtarget',      $backtarget);
-    $this->assignRef('backtext',        $backtext);
-    $this->assignRef('numberofpics',    $numbers[0]);
-    $this->assignRef('numberofhits',    $numbers[1]);
+    $this->_doc->addScriptDeclaration('    var jg_inputcounter = '.$this->inputcounter.';');
 
     JHtml::_('behavior.formvalidation');
     JHtml::_('behavior.tooltip');
@@ -151,7 +142,7 @@ class JoomGalleryViewUpload extends JoomGalleryView
     $this->ajax_form    = JForm::getInstance(_JOOM_OPTION.'.ajaxupload', 'ajaxupload');
     $this->batch_form   = JForm::getInstance(_JOOM_OPTION.'.batchupload', 'batchupload');
     $this->applet_form  = JForm::getInstance(_JOOM_OPTION.'.jupload', 'jupload');
-    $this->single_form->setFieldAttribute('arrscreenshot', 'quantity', $inputcounter);
+    $this->single_form->setFieldAttribute('arrscreenshot', 'quantity', $this->inputcounter);
 
     $this->_doc->addScriptDeclaration('    var jg_filenamewithjs = '.($this->_config->get('jg_filenamewithjs') ? 'true' : 'false').';');
     $this->_doc->addScript($this->_ambit->getScript('upload.js'));

--- a/media/joomgallery/css/admin.joomgallery.css
+++ b/media/joomgallery/css/admin.joomgallery.css
@@ -231,10 +231,10 @@ label#rules-lbl {
   margin: 0 4px 4px 4px;
 }
 
-#editimages-form #imgtitlestartcounter,
-#editimages-form #txtclearvotes,
-#editimages-form #txtclearhits,
-#editimages-form #txtcleardownloads {
+#editimages-form #jform_imgtitlestartcounter,
+#editimages-form #jform_txtclearvotes,
+#editimages-form #jform_txtclearhits,
+#editimages-form #jform_txtcleardownloads {
   width: auto;  
 }
 

--- a/script.php
+++ b/script.php
@@ -41,9 +41,9 @@ class Com_JoomGalleryInstallerScript
    */
   public function preflight($type = 'install')
   {
-    if(version_compare(JVERSION, '4.0', 'ge') || version_compare(JVERSION, '3.0', 'lt'))
+    if(version_compare(JVERSION, '5.0', 'ge') || version_compare(JVERSION, '3.0', 'lt'))
     {
-      JError::raiseWarning(500, 'JoomGallery 3.x is only compatible to Joomla! 3.x');
+      JFactory::getApplication()->enqueueMessage('JoomGallery 4.x is only compatible to Joomla! 4.x', 'error');
 
       return false;
     }
@@ -93,6 +93,7 @@ class Com_JoomGalleryInstallerScript
 
     $row = JTable::getInstance('module');
     $row->title     = 'JoomGallery News';
+    $row->content   = '';
     $row->ordering  = 1;
     $row->position  = 'joom_cpanel';
     $row->published = 1;
@@ -123,7 +124,7 @@ class Com_JoomGalleryInstallerScript
     $query->set('moduleid = '.$row->id);
     $query->set('menuid = 0');
     $db->setQuery($query);
-    if(!$db->query())
+    if(!$db->execute())
     {
       $app->enqueueMessage(JText::_('Unable to assign feed module!'), 'error');
     }
@@ -177,7 +178,7 @@ class Com_JoomGalleryInstallerScript
     {
       if(!JFile::delete(JPATH_ROOT.'/media/joomgallery/css/joom_settings.temp.css'))
       {
-        JError::raiseWarning(500, JText::_('Unable to delete temporary joom_settings.temp.css!'));
+        JFactory::getApplication()->enqueueMessage(JText::_('Unable to delete temporary joom_settings.temp.css!'), 'error');
 
         $error = true;
       }
@@ -377,7 +378,7 @@ class Com_JoomGalleryInstallerScript
         <a title="Languages" class="btn btn-primary" onclick="location.href='index.php?option=com_joomgallery&controller=help'; return false;" href="#">Languages</a>
       </p>
     </div>
-    <?php JHtml::_('bootstrap.modal', 'jg-changelog-popup'); ?>
+    <?php JHtmlBootstrap::renderModal('jg-changelog-popup'); ?>
     <div class="modal hide fade" tabindex="-1" role="dialog" aria-labelledby="PopupChangelogModalLabel" aria-hidden="true" id="jg-changelog-popup">
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>


### PR DESCRIPTION
## First small step on the way to JoomGallery 4.

- JRequest -> JInput
- JError::raiseNotice(), JError::raiseWarning(), -> CMSApplication::enqueueMessage()
- JError::raiseError -> throw Exception
- JDatabase::query() -> JDatabaseDriver::execute()
- getApplication('site') or getApplication('admin') -> getApplication()
- HtmlView::assignRef() -> native PHP syntax
- JArrayHelper -> ArrayHelper

## Test instructions:
 **All gallery functions in front and backend should be tested thoroughly within the actual Joomla! 3.x.**

This also installs on the actual Joomla! 4.0-dev branch but not very much more. It shows only, how much work is still to do on the way to JoomGallery 4 :-) .