### PR TITLE
Fix rowcount for class jg row

### DIFF
--- a/components/com_joomgallery/interface.php
+++ b/components/com_joomgallery/interface.php
@@ -797,7 +797,7 @@ class JoomInterface
     $return     = '';
     //$return    .= "\n".'<div class="gallerytab">'."\n";
     $return    .= '<div class="jg_row jg_row1">';
-    $rowcount   = 0;
+    $rowcount   = 1;
     $itemcount  = 0;
 
     foreach($rows as $row)


### PR DESCRIPTION
When using JoomPlu the class 'jg_row1' at the beginning appears twice. This pull request should be fix it.