### PR TITLE
Change author/owner in frontend upload

### DIFF
--- a/administrator/components/com_joomgallery/models/fields/fineuploader.php
+++ b/administrator/components/com_joomgallery/models/fields/fineuploader.php
@@ -275,12 +275,12 @@ class JFormFieldFineuploader extends JFormField
       }
       <?php if(!$isMini): ?>
       uploader.requestParams.imgtext = jQuery('#<?php echo $prefix; ?>imgtext').val();
+      uploader.requestParams.imgauthor = jQuery('#<?php echo $prefix; ?>imgauthor').val();
       uploader.requestParams.debug = jQuery('#<?php echo $prefix; ?>debug').prop('checked') ? 1 : 0;
       <?php   if($app->isSite()): ?>
       uploader.requestParams.published = jQuery('#<?php echo $prefix; ?>published').val();
       <?php   else: ?>
       uploader.requestParams.published = jQuery('#<?php echo $prefix; ?>published0').prop('checked') ? 0 : 1;
-      uploader.requestParams.imgauthor = jQuery('#<?php echo $prefix; ?>imgauthor').val();
       uploader.requestParams.access = jQuery('#<?php echo $prefix; ?>access').val();
       <?php   endif;
             else: ?>

--- a/components/com_joomgallery/models/forms/ajaxupload.xml
+++ b/components/com_joomgallery/models/forms/ajaxupload.xml
@@ -57,6 +57,13 @@
         type="text"
         class="inputbox"
         label="COM_JOOMGALLERY_COMMON_AUTHOR"
+      />
+      <field
+        name="owner"
+        id="ajax-owner"
+        type="text"
+        class="inputbox"
+        label="COM_JOOMGALLERY_COMMON_OWNER"
         disabled="true"
         readonly="true"
       />

--- a/components/com_joomgallery/models/forms/batchupload.xml
+++ b/components/com_joomgallery/models/forms/batchupload.xml
@@ -55,6 +55,13 @@
         type="text"
         class="inputbox"
         label="COM_JOOMGALLERY_COMMON_AUTHOR"
+      />
+      <field
+        name="owner"
+        id="batch-owner"
+        type="text"
+        class="inputbox"
+        label="COM_JOOMGALLERY_COMMON_OWNER"
         disabled="true"
         readonly="true"
       />

--- a/components/com_joomgallery/models/forms/jupload.xml
+++ b/components/com_joomgallery/models/forms/jupload.xml
@@ -42,6 +42,13 @@
         type="text"
         class="inputbox"
         label="COM_JOOMGALLERY_COMMON_AUTHOR"
+      />
+      <field
+        name="owner"
+        id="java-owner"
+        type="text"
+        class="inputbox"
+        label="COM_JOOMGALLERY_COMMON_OWNER"
         disabled="true"
         readonly="true"
       />

--- a/components/com_joomgallery/models/forms/upload.xml
+++ b/components/com_joomgallery/models/forms/upload.xml
@@ -56,6 +56,13 @@
         type="text"
         class="inputbox"
         label="COM_JOOMGALLERY_COMMON_AUTHOR"
+      />
+      <field
+        name="owner"
+        id="single-owner"
+        type="text"
+        class="inputbox"
+        label="COM_JOOMGALLERY_COMMON_OWNER"
         disabled="true"
         readonly="true"
       />

--- a/components/com_joomgallery/views/upload/tmpl/default_ajax.php
+++ b/components/com_joomgallery/views/upload/tmpl/default_ajax.php
@@ -59,6 +59,14 @@
       <?php echo $this->ajax_form->getLabel('imgauthor'); ?>
     </div>
     <div class="controls">
+      <?php echo $this->ajax_form->getInput('imgauthor'); ?>
+    </div>
+  </div>
+  <div class="control-group">
+    <div class="control-label">
+      <?php echo $this->ajax_form->getLabel('owner'); ?>
+    </div>
+    <div class="controls">
       <div class="jg-uploader"><?php echo JHtml::_('joomgallery.displayname', $this->_user->get('id'), 'upload'); ?></div>
     </div>
   </div>

--- a/components/com_joomgallery/views/upload/tmpl/default_batch.php
+++ b/components/com_joomgallery/views/upload/tmpl/default_batch.php
@@ -45,6 +45,14 @@
       <?php echo $this->batch_form->getLabel('imgauthor'); ?>
     </div>
     <div class="controls">
+      <?php echo $this->batch_form->getInput('imgauthor'); ?>
+    </div>
+  </div>
+  <div class="control-group">
+    <div class="control-label">
+      <?php echo $this->batch_form->getLabel('owner'); ?>
+    </div>
+    <div class="controls">
       <div class="jg-uploader"><?php echo JHtml::_('joomgallery.displayname', $this->_user->get('id'), 'upload'); ?></div>
     </div>
   </div>

--- a/components/com_joomgallery/views/upload/tmpl/default_java.php
+++ b/components/com_joomgallery/views/upload/tmpl/default_java.php
@@ -35,6 +35,14 @@
       <?php echo $this->applet_form->getLabel('imgauthor'); ?>
     </div>
     <div class="controls">
+      <?php echo $this->applet_form->getInput('imgauthor'); ?>
+    </div>
+  </div>
+  <div class="control-group">
+    <div class="control-label">
+      <?php echo $this->applet_form->getLabel('owner'); ?>
+    </div>
+    <div class="controls">
       <div class="jg-uploader"><?php echo JHtml::_('joomgallery.displayname', $this->_user->get('id'), 'upload'); ?></div>
     </div>
   </div>

--- a/components/com_joomgallery/views/upload/tmpl/default_single.php
+++ b/components/com_joomgallery/views/upload/tmpl/default_single.php
@@ -41,6 +41,14 @@
       <?php echo $this->single_form->getLabel('imgauthor'); ?>
     </div>
     <div class="controls">
+      <?php echo $this->single_form->getInput('imgauthor'); ?>
+    </div>
+  </div>
+  <div class="control-group">
+    <div class="control-label">
+      <?php echo $this->single_form->getLabel('owner'); ?>
+    </div>
+    <div class="controls">
       <div class="jg-uploader"><?php echo JHtml::_('joomgallery.displayname', $this->_user->get('id'), 'upload'); ?></div>
     </div>
   </div>


### PR DESCRIPTION
I think in the frontend upload the 'owner' label is incorrectly designated as 'author' and the 'author' is currently not available to enter.
I think 'owner' is a Joomla! user and 'author' is a free text field.
This PR allows you to enter the 'author' during the frontend upload and renames the 'owner' label. I think this is more consistent.