### PR TITLE
Add quality parameter for zip download

### DIFF
--- a/components/com_joomgallery/models/favourites.php
+++ b/components/com_joomgallery/models/favourites.php
@@ -650,7 +650,8 @@ class JoomGalleryModelFavourites extends JoomGalleryModel
             imagegif($imgres);
             break;
           case 2:
-            imagejpeg($imgres);
+            $quali = $this->_config->get('jg_picturequality');
+            imagejpeg($imgres, null, $quali);
             break;
           case 3:
             imagepng($imgres);


### PR DESCRIPTION
Currently there is no quality parameter for generating the images in the zip download. PHP use a standard value (75) then. This PR adds the quality parameter from the JoomGallery configuration.

Maybe we should do this [here](https://github.com/JoomGallery/JoomGallery/blob/b636939e06362d020b659baadb53d7f627386b43/components/com_joomgallery/views/image/view.raw.php#L237-L238) to?