### PR TITLE
Extended  Category Settings

### DIFF
--- a/administrator/components/com_joomgallery/models/forms/category.xml
+++ b/administrator/components/com_joomgallery/models/forms/category.xml
@@ -91,75 +91,75 @@
     <field
       id="allow_download"
       name="allow_download"
-      type="radio"
+      type="list"
       class="btn-group"
       label="COM_JOOMGALLERY_CATMAN_ALLOW_DOWNLOAD"
       description="COM_JOOMGALLERY_CATMAN_ALLOW_DOWNLOAD_TIP"
     >
-      <option value="-1">
-        JNO</option>
       <option value="0">
-        JGLOBAL_USE_GLOBAL</option>
+        JNO</option>
+      <option value="-1">
+        COM_JOOMGALLERY_COMMON_USE_JG_CONFIGURATION</option>
       <option value="1">
         JYES</option>
     </field>
     <field
       id="allow_comment"
       name="allow_comment"
-      type="radio"
+      type="list"
       class="btn-group"
       label="COM_JOOMGALLERY_CATMAN_ALLOW_COMMENT"
       description="COM_JOOMGALLERY_CATMAN_ALLOW_COMMENT_TIP"
     >
-      <option value="-1">
-        JNO</option>
       <option value="0">
-        JGLOBAL_USE_GLOBAL</option>
+        JNO</option>
+      <option value="-1">
+        COM_JOOMGALLERY_COMMON_USE_JG_CONFIGURATION</option>
       <option value="1">
         JYES</option>
     </field>
     <field
       id="allow_rating"
       name="allow_rating"
-      type="radio"
+      type="list"
       class="btn-group"
       label="COM_JOOMGALLERY_CATMAN_ALLOW_RATING"
       description="COM_JOOMGALLERY_CATMAN_ALLOW_RATING_TIP"
     >
-      <option value="-1">
-        JNO</option>
       <option value="0">
-        JGLOBAL_USE_GLOBAL</option>
+        JNO</option>
+      <option value="-1">
+        COM_JOOMGALLERY_COMMON_USE_JG_CONFIGURATION</option>
       <option value="1">
         JYES</option>
     </field>
     <field
       id="allow_watermark"
       name="allow_watermark"
-      type="radio"
+      type="list"
       class="btn-group"
       label="COM_JOOMGALLERY_CATMAN_ALLOW_WATERMARK"
       description="COM_JOOMGALLERY_CATMAN_ALLOW_WATERMARK_TIP"
     >
-      <option value="-1">
-        JNO</option>
       <option value="0">
-        JGLOBAL_USE_GLOBAL</option>
+        JNO</option>
+      <option value="-1">
+        COM_JOOMGALLERY_COMMON_USE_JG_CONFIGURATION</option>
       <option value="1">
         JYES</option>
     </field>
     <field
       id="allow_watermark_download"
       name="allow_watermark_download"
-      type="radio"
+      type="list"
       class="btn-group"
       label="COM_JOOMGALLERY_CATMAN_ALLOW_WATERMARK_DOWNLOAD"
       description="COM_JOOMGALLERY_CATMAN_ALLOW_WATERMARK_DOWNLOAD_TIP"
     >
-      <option value="-1">
-        JNO</option>
       <option value="0">
-        JGLOBAL_USE_GLOBAL</option>
+        JNO</option>
+      <option value="-1">
+        COM_JOOMGALLERY_COMMON_USE_JG_CONFIGURATION</option>
       <option value="1">
         JYES</option>
     </field>

--- a/administrator/components/com_joomgallery/models/forms/category.xml
+++ b/administrator/components/com_joomgallery/models/forms/category.xml
@@ -89,6 +89,81 @@
         JYES</option>
     </field>
     <field
+      id="allow_download"
+      name="allow_download"
+      type="radio"
+      class="btn-group"
+      label="COM_JOOMGALLERY_CATMAN_ALLOW_DOWNLOAD"
+      description="COM_JOOMGALLERY_CATMAN_ALLOW_DOWNLOAD_TIP"
+    >
+      <option value="-1">
+        JNO</option>
+      <option value="0">
+        JGLOBAL_USE_GLOBAL</option>
+      <option value="1">
+        JYES</option>
+    </field>
+    <field
+      id="allow_comment"
+      name="allow_comment"
+      type="radio"
+      class="btn-group"
+      label="COM_JOOMGALLERY_CATMAN_ALLOW_COMMENT"
+      description="COM_JOOMGALLERY_CATMAN_ALLOW_COMMENT_TIP"
+    >
+      <option value="-1">
+        JNO</option>
+      <option value="0">
+        JGLOBAL_USE_GLOBAL</option>
+      <option value="1">
+        JYES</option>
+    </field>
+    <field
+      id="allow_rating"
+      name="allow_rating"
+      type="radio"
+      class="btn-group"
+      label="COM_JOOMGALLERY_CATMAN_ALLOW_RATING"
+      description="COM_JOOMGALLERY_CATMAN_ALLOW_RATING_TIP"
+    >
+      <option value="-1">
+        JNO</option>
+      <option value="0">
+        JGLOBAL_USE_GLOBAL</option>
+      <option value="1">
+        JYES</option>
+    </field>
+    <field
+      id="allow_watermark"
+      name="allow_watermark"
+      type="radio"
+      class="btn-group"
+      label="COM_JOOMGALLERY_CATMAN_ALLOW_WATERMARK"
+      description="COM_JOOMGALLERY_CATMAN_ALLOW_WATERMARK_TIP"
+    >
+      <option value="-1">
+        JNO</option>
+      <option value="0">
+        JGLOBAL_USE_GLOBAL</option>
+      <option value="1">
+        JYES</option>
+    </field>
+    <field
+      id="allow_watermark_download"
+      name="allow_watermark_download"
+      type="radio"
+      class="btn-group"
+      label="COM_JOOMGALLERY_CATMAN_ALLOW_WATERMARK_DOWNLOAD"
+      description="COM_JOOMGALLERY_CATMAN_ALLOW_WATERMARK_DOWNLOAD_TIP"
+    >
+      <option value="-1">
+        JNO</option>
+      <option value="0">
+        JGLOBAL_USE_GLOBAL</option>
+      <option value="1">
+        JYES</option>
+    </field>
+    <field
       name="description"
       type="editor"
       label="COM_JOOMGALLERY_COMMON_DESCRIPTION"

--- a/administrator/components/com_joomgallery/sql/install.mysql.utf8.sql
+++ b/administrator/components/com_joomgallery/sql/install.mysql.utf8.sql
@@ -62,16 +62,16 @@ CREATE TABLE IF NOT EXISTS `#__joomgallery_catg` (
   `metadesc` text NOT NULL,
   `exclude_toplists` int(1) NOT NULL,
   `exclude_search` int(1) NOT NULL,
-  `allow_download` int(1) NOT NULL,
-  `allow_comment` int(1) NOT NULL,
-  `allow_rating` int(1) NOT NULL,
-  `allow_watermark` int(1) NOT NULL,
-  `allow_watermark_download` int(1) NOT NULL,
+  `allow_download` int(1) NOT NULL default -1,
+  `allow_comment` int(1) NOT NULL default -1,
+  `allow_rating` int(1) NOT NULL default -1,
+  `allow_watermark` int(1) NOT NULL default -1,
+  `allow_watermark_download` int(1) NOT NULL default -1,
   PRIMARY KEY (`cid`),
   INDEX idx_parent_id (`parent_id`)
 ) DEFAULT CHARSET=utf8;
 
-INSERT INTO `#__joomgallery_catg` VALUES ('1', '0', 'ROOT', 'root', '0', '0', '0', '0', NULL, '1', '1', '0', '0', '', '0', NULL, '0', '', '', '', '', 0, 0, 0, 0, 0, 0, 0);
+INSERT INTO `#__joomgallery_catg` VALUES ('1', '0', 'ROOT', 'root', '0', '0', '0', '0', NULL, '1', '1', '0', '0', '', '0', NULL, '0', '', '', '', '', 0, 0, -1, -1, -1, -1, -1);
 
 CREATE TABLE IF NOT EXISTS `#__joomgallery_comments` (
   `cmtid` int(11) NOT NULL auto_increment,

--- a/administrator/components/com_joomgallery/sql/install.mysql.utf8.sql
+++ b/administrator/components/com_joomgallery/sql/install.mysql.utf8.sql
@@ -62,11 +62,16 @@ CREATE TABLE IF NOT EXISTS `#__joomgallery_catg` (
   `metadesc` text NOT NULL,
   `exclude_toplists` int(1) NOT NULL,
   `exclude_search` int(1) NOT NULL,
+  `allow_download` int(1) NOT NULL,
+  `allow_comment` int(1) NOT NULL,
+  `allow_rating` int(1) NOT NULL,
+  `allow_watermark` int(1) NOT NULL,
+  `allow_watermark_download` int(1) NOT NULL,
   PRIMARY KEY (`cid`),
   INDEX idx_parent_id (`parent_id`)
 ) DEFAULT CHARSET=utf8;
 
-INSERT INTO `#__joomgallery_catg` VALUES ('1', '0', 'ROOT', 'root', '0', '0', '0', '0', NULL, '1', '1', '0', '0', '', '0', NULL, '0', '', '', '', '', 0, 0);
+INSERT INTO `#__joomgallery_catg` VALUES ('1', '0', 'ROOT', 'root', '0', '0', '0', '0', NULL, '1', '1', '0', '0', '', '0', NULL, '0', '', '', '', '', 0, 0, 0, 0, 0, 0, 0);
 
 CREATE TABLE IF NOT EXISTS `#__joomgallery_comments` (
   `cmtid` int(11) NOT NULL auto_increment,

--- a/administrator/components/com_joomgallery/sql/updates/mysql/3.4.0.sql
+++ b/administrator/components/com_joomgallery/sql/updates/mysql/3.4.0.sql
@@ -1,13 +1,13 @@
 ALTER TABLE `#__joomgallery_countstop` MODIFY `csip` VARCHAR(45) NOT NULL DEFAULT '';
 
-ALTER TABLE `#__joomgallery_catg` ADD `allow_download` int(1) NOT NULL AFTER `exclude_search`;
-ALTER TABLE `#__joomgallery_catg` ADD `allow_comment` int(1) NOT NULL AFTER `allow_download`;
-ALTER TABLE `#__joomgallery_catg` ADD `allow_rating` int(1) NOT NULL AFTER `allow_comment`;
-ALTER TABLE `#__joomgallery_catg` ADD `allow_watermark` int(1) NOT NULL AFTER `allow_rating`;
-ALTER TABLE `#__joomgallery_catg` ADD `allow_watermark_download` int(1) NOT NULL AFTER `allow_watermark`;
+ALTER TABLE `#__joomgallery_catg` ADD `allow_download` int(1) NOT NULL default -1 AFTER `exclude_search`;
+ALTER TABLE `#__joomgallery_catg` ADD `allow_comment` int(1) NOT NULL default -1 AFTER `allow_download`;
+ALTER TABLE `#__joomgallery_catg` ADD `allow_rating` int(1) NOT NULL default -1 AFTER `allow_comment`;
+ALTER TABLE `#__joomgallery_catg` ADD `allow_watermark` int(1) NOT NULL default -1 AFTER `allow_rating`;
+ALTER TABLE `#__joomgallery_catg` ADD `allow_watermark_download` int(1) NOT NULL default -1 AFTER `allow_watermark`;
 
-UPDATE `#__joomgallery_catg` SET `allow_download` = 0;
-UPDATE `#__joomgallery_catg` SET `allow_comment` = 0;
-UPDATE `#__joomgallery_catg` SET `allow_rating` = 0;
-UPDATE `#__joomgallery_catg` SET `allow_watermark` = 0;
-UPDATE `#__joomgallery_catg` SET `allow_watermark_download` = 0;
+UPDATE `#__joomgallery_catg` SET `allow_download` = -1;
+UPDATE `#__joomgallery_catg` SET `allow_comment` = -1;
+UPDATE `#__joomgallery_catg` SET `allow_rating` = -1;
+UPDATE `#__joomgallery_catg` SET `allow_watermark` = -1;
+UPDATE `#__joomgallery_catg` SET `allow_watermark_download` = -1;

--- a/administrator/components/com_joomgallery/sql/updates/mysql/3.4.0.sql
+++ b/administrator/components/com_joomgallery/sql/updates/mysql/3.4.0.sql
@@ -1,1 +1,13 @@
 ALTER TABLE `#__joomgallery_countstop` MODIFY `csip` VARCHAR(45) NOT NULL DEFAULT '';
+
+ALTER TABLE `#__joomgallery_catg` ADD `allow_download` int(1) NOT NULL AFTER `exclude_search`;
+ALTER TABLE `#__joomgallery_catg` ADD `allow_comment` int(1) NOT NULL AFTER `allow_download`;
+ALTER TABLE `#__joomgallery_catg` ADD `allow_rating` int(1) NOT NULL AFTER `allow_comment`;
+ALTER TABLE `#__joomgallery_catg` ADD `allow_watermark` int(1) NOT NULL AFTER `allow_rating`;
+ALTER TABLE `#__joomgallery_catg` ADD `allow_watermark_download` int(1) NOT NULL AFTER `allow_watermark`;
+
+UPDATE `#__joomgallery_catg` SET `allow_download` = 0;
+UPDATE `#__joomgallery_catg` SET `allow_comment` = 0;
+UPDATE `#__joomgallery_catg` SET `allow_rating` = 0;
+UPDATE `#__joomgallery_catg` SET `allow_watermark` = 0;
+UPDATE `#__joomgallery_catg` SET `allow_watermark_download` = 0;

--- a/administrator/components/com_joomgallery/sql/updates/mysql/3.4.0.sql
+++ b/administrator/components/com_joomgallery/sql/updates/mysql/3.4.0.sql
@@ -5,9 +5,3 @@ ALTER TABLE `#__joomgallery_catg` ADD `allow_comment` int(1) NOT NULL default -1
 ALTER TABLE `#__joomgallery_catg` ADD `allow_rating` int(1) NOT NULL default -1 AFTER `allow_comment`;
 ALTER TABLE `#__joomgallery_catg` ADD `allow_watermark` int(1) NOT NULL default -1 AFTER `allow_rating`;
 ALTER TABLE `#__joomgallery_catg` ADD `allow_watermark_download` int(1) NOT NULL default -1 AFTER `allow_watermark`;
-
-UPDATE `#__joomgallery_catg` SET `allow_download` = -1;
-UPDATE `#__joomgallery_catg` SET `allow_comment` = -1;
-UPDATE `#__joomgallery_catg` SET `allow_rating` = -1;
-UPDATE `#__joomgallery_catg` SET `allow_watermark` = -1;
-UPDATE `#__joomgallery_catg` SET `allow_watermark_download` = -1;

--- a/administrator/components/com_joomgallery/tables/joomgallerycategories.php
+++ b/administrator/components/com_joomgallery/tables/joomgallerycategories.php
@@ -61,6 +61,16 @@ class TableJoomgalleryCategories extends JTableNested
   public $exclude_toplists  = 0;
   /** @var int */
   public $exclude_search    = 0;
+  /** @var int */
+  public $allow_download    = 0;
+  /** @var int */
+  public $allow_comment     = 0;
+  /** @var int */
+  public $allow_rating      = 0;
+  /** @var int */
+  public $allow_watermark   = 0;
+  /** @var int */
+  public $allow_watermark_download   = 0;
 
   /**
    * Helper variable for checking whether

--- a/administrator/components/com_joomgallery/tables/joomgallerycategories.php
+++ b/administrator/components/com_joomgallery/tables/joomgallerycategories.php
@@ -62,15 +62,15 @@ class TableJoomgalleryCategories extends JTableNested
   /** @var int */
   public $exclude_search    = 0;
   /** @var int */
-  public $allow_download    = 0;
+  public $allow_download    = -1;
   /** @var int */
-  public $allow_comment     = 0;
+  public $allow_comment     = -1;
   /** @var int */
-  public $allow_rating      = 0;
+  public $allow_rating      = -1;
   /** @var int */
-  public $allow_watermark   = 0;
+  public $allow_watermark   = -1;
   /** @var int */
-  public $allow_watermark_download   = 0;
+  public $allow_watermark_download = -1;
 
   /**
    * Helper variable for checking whether

--- a/administrator/components/com_joomgallery/views/category/tmpl/form.php
+++ b/administrator/components/com_joomgallery/views/category/tmpl/form.php
@@ -254,7 +254,7 @@
             </div>
           </div>
           <div class="span6">
-        <?php echo $this->loadTemplate('options'); ?>
+            <?php echo $this->loadTemplate('options'); ?>
           </div>
         </div>
       </div>

--- a/administrator/components/com_joomgallery/views/category/tmpl/form.php
+++ b/administrator/components/com_joomgallery/views/category/tmpl/form.php
@@ -210,7 +210,53 @@
         </div>
       </div>
       <div class="tab-pane" id="options">
+        <div class="row-fluid">
+          <div class="span6">
+            <div class="control-group">
+              <div class="control-label">
+                <?php echo $this->form->getLabel('allow_download'); ?>
+              </div>
+              <div class="controls">
+                <?php echo $this->form->getInput('allow_download'); ?>
+              </div>
+            </div>
+            <div class="control-group">
+              <div class="control-label">
+                <?php echo $this->form->getLabel('allow_comment'); ?>
+              </div>
+              <div class="controls">
+                <?php echo $this->form->getInput('allow_comment'); ?>
+              </div>
+            </div>
+            <div class="control-group">
+              <div class="control-label">
+                <?php echo $this->form->getLabel('allow_rating'); ?>
+              </div>
+              <div class="controls">
+                <?php echo $this->form->getInput('allow_rating'); ?>
+              </div>
+            </div>
+            <div class="control-group">
+              <div class="control-label">
+                <?php echo $this->form->getLabel('allow_watermark'); ?>
+              </div>
+              <div class="controls">
+                <?php echo $this->form->getInput('allow_watermark'); ?>
+              </div>
+            </div>
+            <div class="control-group">
+              <div class="control-label">
+                <?php echo $this->form->getLabel('allow_watermark_download'); ?>
+              </div>
+              <div class="controls">
+                <?php echo $this->form->getInput('allow_watermark_download'); ?>
+              </div>
+            </div>
+          </div>
+          <div class="span6">
         <?php echo $this->loadTemplate('options'); ?>
+          </div>
+        </div>
       </div>
       <div class="tab-pane" id="metadata">
         <?php echo $this->loadTemplate('metadata'); ?>

--- a/administrator/language/en-GB/en-GB.com_joomgallery.ini
+++ b/administrator/language/en-GB/en-GB.com_joomgallery.ini
@@ -1563,3 +1563,18 @@ COM_JOOMGALLERY_HLPIFO_TEAM_CONTRIBUTORS="The most active contributors to the ma
 ;New
 ;-------
 COM_JOOMGALLERY_UPLOAD_OUTPUT_MAX_ALLOWED_FILESIZE="Error: Max allowed file size is %s byte"
+;
+;------------------------------------------------------------------------------------
+; Deleted, new or changed constants since JoomGallery 3.4.0
+;------------------------------------------------------------------------------------
+; New
+COM_JOOMGALLERY_CATMAN_ALLOW_DOWNLOAD="Offer Downloads"
+COM_JOOMGALLERY_CATMAN_ALLOW_DOWNLOAD_TIP="Here you can set whether the download is allowed in this category.<br />This can overwrite the setting in tab 'User Access Rights->Download->Offer Downloads' in JoomGallery Configuration Manager"
+COM_JOOMGALLERY_CATMAN_ALLOW_COMMENT="Allow Comments"
+COM_JOOMGALLERY_CATMAN_ALLOW_COMMENT_TIP="Here you can set whether the commenting is allowed in this category.<br />This can overwrite the setting in tab 'User Access Rights->Comments->Allow comments' in JoomGallery Configuration Manager"
+COM_JOOMGALLERY_CATMAN_ALLOW_RATING="Allow Rating"
+COM_JOOMGALLERY_CATMAN_ALLOW_RATING_TIP="Here you can set whether the rating is allowed in this category.<br />This can overwrite the setting in tab 'User Access Rights->Ratings->Allow Rating' in JoomGallery Configuration Manager"
+COM_JOOMGALLERY_CATMAN_ALLOW_WATERMARK="Add Watermark"
+COM_JOOMGALLERY_CATMAN_ALLOW_WATERMARK_TIP="Here you can set whether the Watermark is shown in detail/original images in this category.<br />This can overwrite the setting in tab 'Detail View->General Settings->Add Watermark?' in JoomGallery Configuration Manager"
+COM_JOOMGALLERY_CATMAN_ALLOW_WATERMARK_DOWNLOAD="Download with Watermark"
+COM_JOOMGALLERY_CATMAN_ALLOW_WATERMARK_DOWNLOAD_TIP="Here you can set whether the Watermark is included in download files in this category.<br />This can overwrite the setting in tab 'User Access Rights->Download->Download with Watermark?' in JoomGallery Configuration Manager"

--- a/administrator/language/en-GB/en-GB.com_joomgallery.ini
+++ b/administrator/language/en-GB/en-GB.com_joomgallery.ini
@@ -1568,6 +1568,7 @@ COM_JOOMGALLERY_UPLOAD_OUTPUT_MAX_ALLOWED_FILESIZE="Error: Max allowed file size
 ; Deleted, new or changed constants since JoomGallery 3.4.0
 ;------------------------------------------------------------------------------------
 ; New
+COM_JOOMGALLERY_COMMON_USE_JG_CONFIGURATION="JoomGallery Configuration"
 COM_JOOMGALLERY_CATMAN_ALLOW_DOWNLOAD="Offer Downloads"
 COM_JOOMGALLERY_CATMAN_ALLOW_DOWNLOAD_TIP="Here you can set whether the download is allowed in this category.<br />This can overwrite the setting in tab 'User Access Rights->Download->Offer Downloads' in JoomGallery Configuration Manager"
 COM_JOOMGALLERY_CATMAN_ALLOW_COMMENT="Allow Comments"

--- a/components/com_joomgallery/controller.php
+++ b/components/com_joomgallery/controller.php
@@ -169,24 +169,19 @@ class JoomGalleryController extends JControllerLegacy
     $this->_db->setQuery($query);
     $catallow_download = $this->_db->loadResult();
 
-    if($catallow_download == -1)
-    {
+    if($catallow_download == 0 || ($catallow_download == -1 && !$this->_config->get('jg_download')))
+    {  
       $this->setRedirect(JRoute::_('index.php?view=gallery', false), JText::_('COM_JOOMGALLERY_COMMON_MSG_NOT_ALLOWED_DOWNLOAD_THIS_CATEGORY'), 'notice');
 
       return;
     }
-    else
-    {
-      // Check permissions in JoomGallery config
-      if(   $catallow_download != 1 &&
-            (!$this->_config->get('jg_download')
-        ||  (!$this->_config->get('jg_download_unreg') && !JFactory::getUser()->get('id')))
-        )
-      {
-        $this->setRedirect(JRoute::_('index.php?view=gallery', false), JText::_('COM_JOOMGALLERY_COMMON_MSG_NOT_ALLOWED_VIEW_IMAGE'), 'notice');
 
-        return;
-      }
+    // Check permissions for guests in JoomGallery config
+    if(!$this->_config->get('jg_download_unreg') && !JFactory::getUser()->get('id'))
+    {
+      $this->setRedirect(JRoute::_('index.php?view=gallery', false), JText::_('COM_JOOMGALLERY_COMMON_MSG_NOT_ALLOWED_VIEW_IMAGE'), 'notice');
+
+      return;
     }
 
     $type = $this->_config->get('jg_downloadfile') ? 'orig' : 'img';

--- a/components/com_joomgallery/controller.php
+++ b/components/com_joomgallery/controller.php
@@ -169,17 +169,11 @@ class JoomGalleryController extends JControllerLegacy
     $this->_db->setQuery($query);
     $catallow_download = $this->_db->loadResult();
 
-    if($catallow_download == 0 || ($catallow_download == -1 && !$this->_config->get('jg_download')))
-    {  
-      $this->setRedirect(JRoute::_('index.php?view=gallery', false), JText::_('COM_JOOMGALLERY_COMMON_MSG_NOT_ALLOWED_DOWNLOAD_THIS_CATEGORY'), 'notice');
-
-      return;
-    }
-
-    // Check permissions for guests in JoomGallery config
-    if(!$this->_config->get('jg_download_unreg') && !JFactory::getUser()->get('id'))
+    if(   !($catallow_download == (-1) ? $this->_config->get('jg_download') : $catallow_download)
+      ||  (!$this->_config->get('jg_download_unreg') && !JFactory::getUser()->get('id'))
+      )
     {
-      $this->setRedirect(JRoute::_('index.php?view=gallery', false), JText::_('COM_JOOMGALLERY_COMMON_MSG_NOT_ALLOWED_VIEW_IMAGE'), 'notice');
+      $this->setRedirect(JRoute::_('index.php?view=gallery', false), JText::_('COM_JOOMGALLERY_COMMON_MSG_NOT_ALLOWED_DOWNLOAD_IMAGE'), 'notice');
 
       return;
     }

--- a/components/com_joomgallery/models/category.php
+++ b/components/com_joomgallery/models/category.php
@@ -442,7 +442,7 @@ class JoomGalleryModelCategory extends JoomGalleryModel
     if(empty($this->_category))
     {
       $query = $this->_db->getQuery(true)
-            ->select('cid, name, parent_id, description, password, owner, metakey, metadesc, params')
+            ->select('cid, name, parent_id, description, password, owner, metakey, metadesc, params, allow_download')
             ->from(_JOOM_TABLE_CATEGORIES)
             ->where('cid       = '.$this->_id)
             ->where('published = 1')

--- a/components/com_joomgallery/models/comments.php
+++ b/components/com_joomgallery/models/comments.php
@@ -83,7 +83,7 @@ class JoomGalleryModelComments extends JoomGalleryModel
     $authorised_viewlevels = implode(',', $this->_user->getAuthorisedViewLevels());
 
     $query = $this->_db->getQuery(true)
-          ->select('c.cid')
+          ->select('c.cid, c.allow_comment')
           ->from(_JOOM_TABLE_IMAGES.' AS a')
           ->leftJoin(_JOOM_TABLE_CATEGORIES.' AS c ON c.cid = a.catid')
           ->where('a.published = 1')
@@ -92,20 +92,15 @@ class JoomGalleryModelComments extends JoomGalleryModel
           ->where('a.access IN ('.$authorised_viewlevels.')')
           ->where('c.access IN ('.$authorised_viewlevels.')');
     $this->_db->setQuery($query);
-    $result = $this->_db->loadResult();
 
-    // check if commenting is allowed in this category
-    $query->clear()
-          ->select('c.allow_comment')
-          ->from(_JOOM_TABLE_IMAGES.' AS a')
-          ->leftJoin(_JOOM_TABLE_CATEGORIES.' AS c ON c.cid = a.catid')
-          ->where('a.published = 1')
-          ->where('a.approved = 1')
-          ->where('a.id = '.$this->_id)
-          ->where('a.access IN ('.$authorised_viewlevels.')')
-          ->where('c.access IN ('.$authorised_viewlevels.')');
-    $this->_db->setQuery($query);
-    $catallow_comment = $this->_db->loadResult();
+    $result           = null;
+    $catallow_comment = -1;
+
+    if(!empty($row = $this->_db->loadRow()))
+    {
+      $result           = $row[0];
+      $catallow_comment = $row[1];
+    }
 
     if(   !$result
       ||  !($catallow_comment == (-1) ? $this->_config->get('jg_showcomment') : $catallow_comment)

--- a/components/com_joomgallery/models/comments.php
+++ b/components/com_joomgallery/models/comments.php
@@ -107,21 +107,13 @@ class JoomGalleryModelComments extends JoomGalleryModel
     $this->_db->setQuery($query);
     $catallow_comment = $this->_db->loadResult();
 
-
-    if(   !$result
+    if(   !($catallow_comment == (-1) ? $this->_config->get('jg_download') : $catallow_comment)
+      ||  !$result
       ||  !$this->_config->get('jg_showcomment')
       || (!$this->_config->get('jg_anoncomment') && !$this->_user->get('id'))
       )
     {
       die('Hacking attempt, aborted!');
-    }
-
-    // No commenting allowed in this category
-    if($catallow_comment == -1)
-    {
-      $this->setError(JText::_('COM_JOOMGALLERY_DETAIL_COMMENTING_NOT_ALLOWED'));
-
-      return false;
     }
 
     $categories = $this->_ambit->getCategoryStructure();

--- a/components/com_joomgallery/models/comments.php
+++ b/components/com_joomgallery/models/comments.php
@@ -107,9 +107,8 @@ class JoomGalleryModelComments extends JoomGalleryModel
     $this->_db->setQuery($query);
     $catallow_comment = $this->_db->loadResult();
 
-    if(   !($catallow_comment == (-1) ? $this->_config->get('jg_download') : $catallow_comment)
-      ||  !$result
-      ||  !$this->_config->get('jg_showcomment')
+    if(   !$result
+      ||  !($catallow_comment == (-1) ? $this->_config->get('jg_showcomment') : $catallow_comment)
       || (!$this->_config->get('jg_anoncomment') && !$this->_user->get('id'))
       )
     {

--- a/components/com_joomgallery/models/detail.php
+++ b/components/com_joomgallery/models/detail.php
@@ -503,7 +503,7 @@ class JoomGalleryModelDetail extends JoomGalleryModel
 
       // Get all the images data of that category
       $query->clear()
-            ->select('a.*, a.owner AS imgowner, c.metadesc AS catmetadesc, c.metakey AS catmetakey')
+            ->select('a.*, a.owner AS imgowner, c.metadesc AS catmetadesc, c.metakey AS catmetakey, c.allow_download as catallow_download, c.allow_comment as catallow_comment, c.allow_rating as catallow_rating')
             ->select(JoomHelper::getSQLRatingClause('a').' AS rating')
             ->from(_JOOM_TABLE_IMAGES.' AS a')
             ->leftJoin(_JOOM_TABLE_CATEGORIES.' AS c ON c.cid = a.catid')

--- a/components/com_joomgallery/models/favourites.php
+++ b/components/com_joomgallery/models/favourites.php
@@ -636,7 +636,7 @@ class JoomGalleryModelFavourites extends JoomGalleryModel
       $this->_db->setQuery($query);
       $cat_allow_watermark_download = $this->_db->loadResult();
 
-      if($cat_allow_watermark_download == 1 || ($cat_allow_watermark_download == 0 && $this->_config->get('jg_downloadwithwatermark')))
+      if(($cat_allow_watermark_download == (-1) ? $this->_config->get('jg_downloadwithwatermark') : $cat_allow_watermark_download))
       {
         $include_watermark = true;
       }

--- a/components/com_joomgallery/models/favourites.php
+++ b/components/com_joomgallery/models/favourites.php
@@ -554,6 +554,7 @@ class JoomGalleryModelFavourites extends JoomGalleryModel
           ->select('id')
           ->select('catid')
           ->select('imgfilename')
+          ->select('allow_watermark_download')
           ->from(_JOOM_TABLE_IMAGES.' AS a')
           ->from(_JOOM_TABLE_CATEGORIES.' AS c')
           ->where('id IN ('.$this->piclist.')')
@@ -585,20 +586,6 @@ class JoomGalleryModelFavourites extends JoomGalleryModel
     // Get the 'image' model
     $imageModel = parent::getInstance('image', 'joomgallerymodel');
 
-    // Get the temp path for storing the watermarked image temporarily
-    if(!JFolder::exists($this->_ambit->get('temp_path')))
-    {
-      $this->setError(JText::_('COM_JOOMGALLERY_UPLOAD_ERROR_TEMP_MISSING'));
-
-      return false;
-    }
-    else
-    {
-      $tmppath = $this->_ambit->get('temp_path');
-    }
-
-    // save info for message
-    $messagebody = '';
     $categories = $this->_ambit->getCategoryStructure();
     foreach($rows as &$row)
     {
@@ -627,16 +614,7 @@ class JoomGalleryModelFavourites extends JoomGalleryModel
       $files[$row->id]['name'] = $row->imgfilename;
 
       // Watermark the image before if needed
-      // check category settings for download with watermark
-      $query = $this->_db->getQuery(true)
-          ->select('c.allow_watermark_download')
-          ->from(_JOOM_TABLE_IMAGES.' AS a')
-          ->innerJoin(_JOOM_TABLE_CATEGORIES.' AS c ON c.cid = a.catid')
-          ->where('a.id         = '.$row->id);
-      $this->_db->setQuery($query);
-      $cat_allow_watermark_download = $this->_db->loadResult();
-
-      if(($cat_allow_watermark_download == (-1) ? $this->_config->get('jg_downloadwithwatermark') : $cat_allow_watermark_download))
+      if(($row->allow_watermark_download == (-1) ? $this->_config->get('jg_downloadwithwatermark') : $row->allow_watermark_download))
       {
         $include_watermark = true;
       }

--- a/components/com_joomgallery/models/search.php
+++ b/components/com_joomgallery/models/search.php
@@ -107,7 +107,7 @@ class JoomGalleryModelSearch extends JoomGalleryModel
       $where .= ')';
 
       // General select clause of the query
-      $query->select('a.*, '.JoomHelper::getSQLRatingClause('a').' AS rating, u.username, ca.cid, ca.name AS name');
+      $query->select('a.*, '.JoomHelper::getSQLRatingClause('a').' AS rating, u.username, ca.cid, ca.name AS name, ca.allow_download AS allow_download');
 
       // Count comments of each image if required
       if($this->_config->get('jg_showcatcom'))

--- a/components/com_joomgallery/models/toplist.php
+++ b/components/com_joomgallery/models/toplist.php
@@ -170,7 +170,7 @@ class JoomGalleryModelToplist extends JoomGalleryModel
       $authorisedViewLevels = implode(',', $this->_user->getAuthorisedViewLevels());
 
       $query = $this->_db->getQuery(true)
-            ->select('*, a.owner AS owner, '.JoomHelper::getSQLRatingClause('a').' AS rating');
+            ->select('*, a.owner AS owner, '.JoomHelper::getSQLRatingClause('a').' AS rating, ca.allow_download AS allow_download');
       if($this->_config->get('jg_showcatcom'))
       {
         $subquery = $this->_db->getQuery(true)
@@ -239,7 +239,7 @@ class JoomGalleryModelToplist extends JoomGalleryModel
       $authorisedViewLevels = implode(',', $this->_user->getAuthorisedViewLevels());
 
       $query = $this->_db->getQuery(true)
-            ->select('*, a.owner AS owner, '.JoomHelper::getSQLRatingClause('a').' AS rating');
+            ->select('*, a.owner AS owner, '.JoomHelper::getSQLRatingClause('a').' AS rating, ca.allow_download AS allow_download');
       if($this->_config->get('jg_showcatcom'))
       {
         $subquery = $this->_db->getQuery(true)
@@ -309,7 +309,7 @@ class JoomGalleryModelToplist extends JoomGalleryModel
       $authorisedViewLevels = implode(',', $this->_user->getAuthorisedViewLevels());
 
       $query = $this->_db->getQuery(true)
-            ->select('*, a.owner AS owner, '.JoomHelper::getSQLRatingClause('a').' AS rating');
+            ->select('*, a.owner AS owner, '.JoomHelper::getSQLRatingClause('a').' AS rating, ca.allow_download AS allow_download');
       if($this->_config->get('jg_showcatcom'))
       {
         $subquery = $this->_db->getQuery(true)

--- a/components/com_joomgallery/models/vote.php
+++ b/components/com_joomgallery/models/vote.php
@@ -80,7 +80,7 @@ class JoomGalleryModelVote extends JoomGalleryModel
     // Check for hacking attempt
     $categories = $this->_ambit->getCategoryStructure();
     $query = $this->_db->getQuery(true)
-          ->select('a.owner')
+          ->select('a.owner, c.allow_rating')
           ->from(_JOOM_TABLE_IMAGES.' AS a')
           ->leftJoin(_JOOM_TABLE_CATEGORIES.' AS c ON c.cid = a.catid')
           ->where('a.published  = 1')
@@ -89,19 +89,15 @@ class JoomGalleryModelVote extends JoomGalleryModel
           ->where('a.access     IN ('.implode(',', $this->_user->getAuthorisedViewLevels()).')')
           ->where('c.cid        IN ('.implode(',', array_keys($categories)).')');
     $this->_db->setQuery($query);
-    $owner = $this->_db->loadResult();
-    // check if rating is allowed in this category
-    $query->clear()
-          ->select('c.allow_rating')
-          ->from(_JOOM_TABLE_IMAGES.' AS a')
-          ->leftJoin(_JOOM_TABLE_CATEGORIES.' AS c ON c.cid = a.catid')
-          ->where('a.published  = 1')
-          ->where('a.approved   = 1')
-          ->where('a.id         = '.$this->_id)
-          ->where('a.access     IN ('.implode(',', $this->_user->getAuthorisedViewLevels()).')')
-          ->where('c.cid        IN ('.implode(',', array_keys($categories)).')');
-    $this->_db->setQuery($query);
-    $catallow_rating = $this->_db->loadResult();
+
+    $owner = null;
+    $catallow_rating = -1;
+
+    if(!empty($row = $this->_db->loadRow()))
+    {
+      $owner = $row[0];
+      $catallow_rating = $row[1];
+    }
 
     if(  !($catallow_rating == (-1) ? $this->_config->get('jg_showrating') : $catallow_rating)
       || (is_null($owner) || ($this->_config->get('jg_votingonlyreg') && !$this->_user->get('id'))))

--- a/components/com_joomgallery/models/vote.php
+++ b/components/com_joomgallery/models/vote.php
@@ -103,7 +103,7 @@ class JoomGalleryModelVote extends JoomGalleryModel
     $this->_db->setQuery($query);
     $catallow_rating = $this->_db->loadResult();
 
-    if($catallow_rating == 1 && (is_null($owner) || ($this->_config->get('jg_votingonlyreg') && !$this->_user->get('id'))))
+    if(is_null($owner) || ($this->_config->get('jg_votingonlyreg') && !$this->_user->get('id')))
     {
       $this->setError('Stop Hacking attempt!');
 
@@ -111,7 +111,7 @@ class JoomGalleryModelVote extends JoomGalleryModel
     }
 
     // No rating in this category allowed
-    if($catallow_rating == -1)
+    if($catallow_rating == 0)
     {
       $this->setError(JText::_('COM_JOOMGALLERY_DETAIL_RATING_NOT_ALLOWED'));
 

--- a/components/com_joomgallery/models/vote.php
+++ b/components/com_joomgallery/models/vote.php
@@ -103,17 +103,10 @@ class JoomGalleryModelVote extends JoomGalleryModel
     $this->_db->setQuery($query);
     $catallow_rating = $this->_db->loadResult();
 
-    if(is_null($owner) || ($this->_config->get('jg_votingonlyreg') && !$this->_user->get('id')))
+    if(  !($catallow_rating == (-1) ? $this->_config->get('jg_showrating') : $catallow_rating)
+      || (is_null($owner) || ($this->_config->get('jg_votingonlyreg') && !$this->_user->get('id'))))
     {
       $this->setError('Stop Hacking attempt!');
-
-      return false;
-    }
-
-    // No rating in this category allowed
-    if($catallow_rating == 0)
-    {
-      $this->setError(JText::_('COM_JOOMGALLERY_DETAIL_RATING_NOT_ALLOWED'));
 
       return false;
     }

--- a/components/com_joomgallery/models/vote.php
+++ b/components/com_joomgallery/models/vote.php
@@ -90,7 +90,7 @@ class JoomGalleryModelVote extends JoomGalleryModel
           ->where('c.cid        IN ('.implode(',', array_keys($categories)).')');
     $this->_db->setQuery($query);
 
-    $owner = null;
+    $owner           = null;
     $catallow_rating = -1;
 
     if(!empty($row = $this->_db->loadRow()))

--- a/components/com_joomgallery/views/category/view.html.php
+++ b/components/com_joomgallery/views/category/view.html.php
@@ -681,20 +681,18 @@ class JoomGalleryViewCategory extends JoomGalleryView
     }
 
     // Download icon
-    if($cat->allow_download != 0)
+    if(  ($cat->allow_download == (-1) ? $this->_config->get('jg_download') : $cat->allow_download)
+      && $this->_config->get('jg_showcategorydownload'))
     {
-      if(($cat->allow_download == 1 || $this->_config->get('jg_download')) && $this->_config->get('jg_showcategorydownload'))
+      if($this->_user->get('id') || $this->_config->get('jg_download_unreg'))
       {
-        if($this->_user->get('id') || $this->_config->get('jg_download_unreg'))
+        $params->set('show_download_icon', 1);
+      }
+      else
+      {
+        if($this->_config->get('jg_download_hint'))
         {
-          $params->set('show_download_icon', 1);
-        }
-        else
-        {
-          if($this->_config->get('jg_download_hint'))
-          {
-            $params->set('show_download_icon', -1);
-          }
+          $params->set('show_download_icon', -1);
         }
       }
     }

--- a/components/com_joomgallery/views/category/view.html.php
+++ b/components/com_joomgallery/views/category/view.html.php
@@ -681,17 +681,21 @@ class JoomGalleryViewCategory extends JoomGalleryView
     }
 
     // Download icon
-    if($this->_config->get('jg_download') && $this->_config->get('jg_showcategorydownload'))
+    if($cat->allow_download != -1)
     {
-      if($this->_user->get('id') || $this->_config->get('jg_download_unreg'))
+      if(   $cat->allow_download == 1
+        || ($this->_config->get('jg_download') && $this->_config->get('jg_showcategorydownload')))
       {
-        $params->set('show_download_icon', 1);
-      }
-      else
-      {
-        if($this->_config->get('jg_download_hint'))
+        if($this->_user->get('id') || $this->_config->get('jg_download_unreg'))
         {
-          $params->set('show_download_icon', -1);
+          $params->set('show_download_icon', 1);
+        }
+        else
+        {
+          if($this->_config->get('jg_download_hint'))
+          {
+            $params->set('show_download_icon', -1);
+          }
         }
       }
     }

--- a/components/com_joomgallery/views/category/view.html.php
+++ b/components/com_joomgallery/views/category/view.html.php
@@ -681,10 +681,9 @@ class JoomGalleryViewCategory extends JoomGalleryView
     }
 
     // Download icon
-    if($cat->allow_download != -1)
+    if($cat->allow_download != 0)
     {
-      if(   $cat->allow_download == 1
-        || ($this->_config->get('jg_download') && $this->_config->get('jg_showcategorydownload')))
+      if(($cat->allow_download == 1 || $this->_config->get('jg_download')) && $this->_config->get('jg_showcategorydownload'))
       {
         if($this->_user->get('id') || $this->_config->get('jg_download_unreg'))
         {

--- a/components/com_joomgallery/views/detail/view.html.php
+++ b/components/com_joomgallery/views/detail/view.html.php
@@ -656,8 +656,7 @@ class JoomGalleryViewDetail extends JoomGalleryView
       }
 
       // Download icon
-      if(   $image->catallow_download == 1 
-        ||  ($image->catallow_download == -1 && $this->_config->get('jg_download'))
+      if(   ($image->catallow_download == (-1) ? $this->_config->get('jg_download') : $image->catallow_download)
         &&  $this->_config->get('jg_showdetaildownload')
         &&  ($image->orig_exists || $this->_config->get('jg_downloadfile') != 1)
         )

--- a/components/com_joomgallery/views/detail/view.html.php
+++ b/components/com_joomgallery/views/detail/view.html.php
@@ -892,7 +892,7 @@ class JoomGalleryViewDetail extends JoomGalleryView
       }
 
       // Rating
-      if($image->catallow_rating == 1 || ($image->catallow_rating == -1 && $this->_config->get('jg_showrating')))
+      if($image->catallow_rating == (-1) ? $this->_config->get('jg_showrating') : $image->catallow_rating)
       {
         if($this->_config->get('jg_votingonlyreg') && !$this->_user->get('id'))
         {
@@ -982,50 +982,41 @@ class JoomGalleryViewDetail extends JoomGalleryView
         }
       }
 
-      // commenting area
-      // check if commenting allowed
-      if($image->catallow_comment == 0)
+      if($image->catallow_comment == (-1) ? $this->_config->get('jg_showcomment') : $image->catallow_comment)
       {
-        $params->set('show_comments_block', 0);
-      }
-      else
-      {
-        if($image->catallow_comment == 1 || $this->_config->get('jg_showcomment'))
+        $params->set('show_comments_block', 1);
+
+        // Check whether user is allowed to comment
+        if(      $this->_config->get('jg_anoncomment')
+            || (!$this->_config->get('jg_anoncomment') && $this->_user->get('id'))
+          )
         {
-          $params->set('show_comments_block', 1);
+          $params->set('commenting_allowed', 1);
 
-          // Check whether user is allowed to comment
-          if(      $this->_config->get('jg_anoncomment')
-              || (!$this->_config->get('jg_anoncomment') && $this->_user->get('id'))
-            )
+          $plugins          = $this->_mainframe->triggerEvent('onJoomGetCaptcha');
+          $event->captchas  = implode('', $plugins);
+
+          $this->_doc->addScriptDeclaration('    var jg_use_code = '.$params->get('use_easycaptcha', 0).';');
+
+          if($this->_config->get('jg_bbcodesupport'))
           {
-            $params->set('commenting_allowed', 1);
-
-            $plugins          = $this->_mainframe->triggerEvent('onJoomGetCaptcha');
-            $event->captchas  = implode('', $plugins);
-
-            $this->_doc->addScriptDeclaration('    var jg_use_code = '.$params->get('use_easycaptcha', 0).';');
-
-            if($this->_config->get('jg_bbcodesupport'))
-            {
-              $params->set('bbcode_status', JText::_('COM_JOOMGALLERY_DETAIL_BBCODE_ON'));
-            }
-            else
-            {
-              $params->set('bbcode_status', JText::_('COM_JOOMGALLERY_DETAIL_BBCODE_OFF'));
-            }
-
-            if($this->_config->get('jg_smiliesupport'))
-            {
-              $params->set('smiley_support', 1);
-              $smileys = JoomHelper::getSmileys();
-              $this->assignRef('smileys', $smileys);
-            }
-
-            JText::script('COM_JOOMGALLERY_DETAIL_SENDTOFRIEND_ALERT_ENTER_NAME_EMAIL');
-            JText::script('COM_JOOMGALLERY_DETAIL_COMMENTS_ALERT_ENTER_COMMENT');
-            JText::script('COM_JOOMGALLERY_DETAIL_COMMENTS_ALERT_ENTER_CODE');
+            $params->set('bbcode_status', JText::_('COM_JOOMGALLERY_DETAIL_BBCODE_ON'));
           }
+          else
+          {
+            $params->set('bbcode_status', JText::_('COM_JOOMGALLERY_DETAIL_BBCODE_OFF'));
+          }
+
+          if($this->_config->get('jg_smiliesupport'))
+          {
+            $params->set('smiley_support', 1);
+            $smileys = JoomHelper::getSmileys();
+            $this->assignRef('smileys', $smileys);
+          }
+
+          JText::script('COM_JOOMGALLERY_DETAIL_SENDTOFRIEND_ALERT_ENTER_NAME_EMAIL');
+          JText::script('COM_JOOMGALLERY_DETAIL_COMMENTS_ALERT_ENTER_COMMENT');
+          JText::script('COM_JOOMGALLERY_DETAIL_COMMENTS_ALERT_ENTER_CODE');
         }
 
         // Check whether user is allowed to read comments

--- a/components/com_joomgallery/views/detail/view.html.php
+++ b/components/com_joomgallery/views/detail/view.html.php
@@ -656,21 +656,31 @@ class JoomGalleryViewDetail extends JoomGalleryView
       }
 
       // Download icon
-      if(   $this->_config->get('jg_download')
+      if($image->catallow_download == -1)
+      {
+        // $params->set('show_download_icon', -1);
+      }
+      else
+      {
+        if(
+            $image->catallow_download == 1
+        || (
+            $this->_config->get('jg_download')
         &&  $this->_config->get('jg_showdetaildownload')
         &&  ($image->orig_exists || $this->_config->get('jg_downloadfile') != 1)
-        )
-      {
-        if($this->_user->get('id') || $this->_config->get('jg_download_unreg'))
+        ))
         {
-          $params->set('show_download_icon', 1);
-          $params->set('download_link', JRoute::_('index.php?task=download&id='.$image->id));
-        }
-        else
-        {
-          if($this->_config->get('jg_download_hint'))
+          if($this->_user->get('id') || $this->_config->get('jg_download_unreg'))
           {
-            $params->set('show_download_icon', -1);
+            $params->set('show_download_icon', 1);
+            $params->set('download_link', JRoute::_('index.php?task=download&id='.$image->id));
+          }
+          else
+          {
+            if($this->_config->get('jg_download_hint'))
+            {
+              $params->set('show_download_icon', -1);
+            }
           }
         }
       }
@@ -892,58 +902,65 @@ class JoomGalleryViewDetail extends JoomGalleryView
       }
 
       // Rating
-      if($this->_config->get('jg_showrating'))
+      if($image->catallow_rating == -1)
       {
-        if($this->_config->get('jg_votingonlyreg') && !$this->_user->get('id'))
+        // $params->set('show_comments_block', 0);
+      }
+      else
+      {
+        if($image->catallow_rating == 1 || $this->_config->get('jg_showrating'))
         {
-          // Set voting_area to 3 to show only the message in template
-          $params->set('show_voting_area', 3);
-          $params->set('voting_message', JText::_('COM_JOOMGALLERY_DETAIL_LOGIN_FIRST'));
-        }
-        else
-        {
-          if($this->_config->get('jg_votingonlyreg') && $image->owner == $this->_user->get('id'))
+          if($this->_config->get('jg_votingonlyreg') && !$this->_user->get('id'))
           {
             // Set voting_area to 3 to show only the message in template
             $params->set('show_voting_area', 3);
-            $params->set('voting_message', JText::_('COM_JOOMGALLERY_DETAIL_RATING_NOT_ON_OWN_IMAGES'));
+            $params->set('voting_message', JText::_('COM_JOOMGALLERY_DETAIL_LOGIN_FIRST'));
           }
           else
           {
-            // Set to 1 will show the voting area
-            JHtml::_('behavior.framework');
-            $params->set('show_voting_area', 1);
-            $params->set('ajaxvoting', $this->_config->get('jg_ajaxrating'));
-            if($this->_config->get('jg_ratingdisplaytype') == 0)
+            if($this->_config->get('jg_votingonlyreg') && $image->owner == $this->_user->get('id'))
             {
-              // Set to 0 will show textual voting bar with radio buttons
-              $params->set('voting_display_type', 0);
-
-              $selected = floor($this->_config->get('jg_maxvoting') / 2) + 1;
-              $voting   = '';
-
-              $options = array();
-              for($i = 1; $i <= $this->_config->get('jg_maxvoting'); $i++)
-              {
-                $options[] = JHTML::_('select.option', $i);
-                // Delete options text manually, because it defaults to the value in JHTML::_('select.option'... ) if left empty
-                $options[$i-1]->text = '';
-              }
-              $voting .= JHTML::_('select.radiolist', $options, 'imgvote', null, 'value', 'text', $selected);
-
-              $maxvoting = $i-1;
-
-              $this->assignRef('voting', $voting);
-              $this->assignRef('maxvoting', $maxvoting);
+              // Set voting_area to 3 to show only the message in template
+              $params->set('show_voting_area', 3);
+              $params->set('voting_message', JText::_('COM_JOOMGALLERY_DETAIL_RATING_NOT_ON_OWN_IMAGES'));
             }
-            else if($this->_config->get('jg_ratingdisplaytype') == 1)
+            else
             {
-              // Set to 1 will show graphical voting bar with stars
-              $params->set('voting_display_type', 1);
+              // Set to 1 will show the voting area
+              JHtml::_('behavior.framework');
+              $params->set('show_voting_area', 1);
+              $params->set('ajaxvoting', $this->_config->get('jg_ajaxrating'));
+              if($this->_config->get('jg_ratingdisplaytype') == 0)
+              {
+                // Set to 0 will show textual voting bar with radio buttons
+                $params->set('voting_display_type', 0);
 
-              $maxvoting = $this->_config->get('jg_maxvoting');
+                $selected = floor($this->_config->get('jg_maxvoting') / 2) + 1;
+                $voting   = '';
 
-              $this->assignRef('maxvoting', $maxvoting);
+                $options = array();
+                for($i = 1; $i <= $this->_config->get('jg_maxvoting'); $i++)
+                {
+                  $options[] = JHTML::_('select.option', $i);
+                  // Delete options text manually, because it defaults to the value in JHTML::_('select.option'... ) if left empty
+                  $options[$i-1]->text = '';
+                }
+                $voting .= JHTML::_('select.radiolist', $options, 'imgvote', null, 'value', 'text', $selected);
+
+                $maxvoting = $i-1;
+
+                $this->assignRef('voting', $voting);
+                $this->assignRef('maxvoting', $maxvoting);
+              }
+              else if($this->_config->get('jg_ratingdisplaytype') == 1)
+              {
+                // Set to 1 will show graphical voting bar with stars
+                $params->set('voting_display_type', 1);
+
+                $maxvoting = $this->_config->get('jg_maxvoting');
+
+                $this->assignRef('maxvoting', $maxvoting);
+              }
             }
           }
         }
@@ -982,41 +999,51 @@ class JoomGalleryViewDetail extends JoomGalleryView
         }
       }
 
-      if($this->_config->get('jg_showcomment'))
+      // commenting area
+      // check if commenting allowed
+      if($image->catallow_comment == -1)
       {
-        $params->set('show_comments_block', 1);
-
-        // Check whether user is allowed to comment
-        if(      $this->_config->get('jg_anoncomment')
-            || (!$this->_config->get('jg_anoncomment') && $this->_user->get('id'))
-          )
+        $params->set('show_comments_block', 0);
+      }
+      else
+      {
+        if($image->catallow_comment == 1 || $this->_config->get('jg_showcomment'))
         {
-          $params->set('commenting_allowed', 1);
+          $params->set('show_comments_block', 1);
 
-          $plugins          = $this->_mainframe->triggerEvent('onJoomGetCaptcha');
-          $event->captchas  = implode('', $plugins);
-
-          $this->_doc->addScriptDeclaration('    var jg_use_code = '.$params->get('use_easycaptcha', 0).';');
-
-          if($this->_config->get('jg_bbcodesupport'))
+          // Check whether user is allowed to comment
+          if(     $image->catallow_comment == 1
+              || ($this->_config->get('jg_anoncomment')
+              || (!$this->_config->get('jg_anoncomment') && $this->_user->get('id')))
+            )
           {
-            $params->set('bbcode_status', JText::_('COM_JOOMGALLERY_DETAIL_BBCODE_ON'));
-          }
-          else
-          {
-            $params->set('bbcode_status', JText::_('COM_JOOMGALLERY_DETAIL_BBCODE_OFF'));
-          }
+            $params->set('commenting_allowed', 1);
 
-          if($this->_config->get('jg_smiliesupport'))
-          {
-            $params->set('smiley_support', 1);
-            $smileys = JoomHelper::getSmileys();
-            $this->assignRef('smileys', $smileys);
-          }
+            $plugins          = $this->_mainframe->triggerEvent('onJoomGetCaptcha');
+            $event->captchas  = implode('', $plugins);
 
-          JText::script('COM_JOOMGALLERY_DETAIL_SENDTOFRIEND_ALERT_ENTER_NAME_EMAIL');
-          JText::script('COM_JOOMGALLERY_DETAIL_COMMENTS_ALERT_ENTER_COMMENT');
-          JText::script('COM_JOOMGALLERY_DETAIL_COMMENTS_ALERT_ENTER_CODE');
+            $this->_doc->addScriptDeclaration('    var jg_use_code = '.$params->get('use_easycaptcha', 0).';');
+
+            if($this->_config->get('jg_bbcodesupport'))
+            {
+              $params->set('bbcode_status', JText::_('COM_JOOMGALLERY_DETAIL_BBCODE_ON'));
+            }
+            else
+            {
+              $params->set('bbcode_status', JText::_('COM_JOOMGALLERY_DETAIL_BBCODE_OFF'));
+            }
+
+            if($this->_config->get('jg_smiliesupport'))
+            {
+              $params->set('smiley_support', 1);
+              $smileys = JoomHelper::getSmileys();
+              $this->assignRef('smileys', $smileys);
+            }
+
+            JText::script('COM_JOOMGALLERY_DETAIL_SENDTOFRIEND_ALERT_ENTER_NAME_EMAIL');
+            JText::script('COM_JOOMGALLERY_DETAIL_COMMENTS_ALERT_ENTER_COMMENT');
+            JText::script('COM_JOOMGALLERY_DETAIL_COMMENTS_ALERT_ENTER_CODE');
+          }
         }
 
         // Check whether user is allowed to read comments

--- a/components/com_joomgallery/views/favourites/tmpl/default.php
+++ b/components/com_joomgallery/views/favourites/tmpl/default.php
@@ -87,11 +87,11 @@ echo $this->loadTemplate('header');?>
           $results = $this->_mainframe->triggerEvent('onJoomAfterDisplayThumb', array($row->id));
           echo implode('', $results) ?>
             <li>
-<?php     if($this->params->get('show_download_icon') == 1): ?>
+<?php     if($row->show_download_icon == 1): ?>
               <a href="<?php echo JRoute::_('index.php?option=com_joomgallery&task=download&id='.$row->id); ?>"<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPTEXT', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPCAPTION', true); ?>>
                 <?php echo JHTML::_('joomgallery.icon', 'download.png', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPCAPTION'); ?></a>
 <?php     endif;
-          if($this->params->get('show_download_icon') == -1): ?>
+          if($row->show_download_icon == -1): ?>
               <span<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_LOGIN_TIPTEXT', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPCAPTION', true); ?>>
                 <?php echo JHTML::_('joomgallery.icon', 'download_gr.png', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPCAPTION'); ?>
               </span>

--- a/components/com_joomgallery/views/favourites/tmpl/list.php
+++ b/components/com_joomgallery/views/favourites/tmpl/list.php
@@ -71,13 +71,13 @@ echo $this->loadTemplate('header'); ?>
             <?php echo JHtml::_('joomgallery.categorypath', $item->catid, true, ' &raquo; ', true, false, true); ?>
           </td>
           <td class="nowrap">
-<?php   if($this->params->get('show_download_icon') == 1): ?>
+<?php   if($item->show_download_icon == 1): ?>
             <div class="pull-left<?php echo JHtml::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPTEXT', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPCAPTION'); ?>">
               <a href="<?php echo JRoute::_('index.php?task=download&id='.$item->id); ?>">
                 <?php echo JHtml::_('joomgallery.icon', 'download.png', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPCAPTION'); ?></a>
             </div>
 <?php   endif;
-        if($this->params->get('show_download_icon') == -1): ?>
+        if($item->show_download_icon == -1): ?>
             <div class="pull-left<?php echo JHtml::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_LOGIN_TIPTEXT', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPCAPTION'); ?>">
               <?php echo JHtml::_('joomgallery.icon', 'download_gr.png', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPCAPTION'); ?>
             </div>

--- a/components/com_joomgallery/views/favourites/view.html.php
+++ b/components/com_joomgallery/views/favourites/view.html.php
@@ -136,20 +136,27 @@ class JoomGalleryViewFavourites extends JoomGalleryView
           $row->show_delete_icon = true;
         }
       }
-    }
 
-    // Download Icon
-    if($this->_config->get('jg_download') && $this->_config->get('jg_showfavouritesdownload'))
-    {
-      if($this->_user->get('id') || $this->_config->get('jg_download_unreg'))
+      // Download Icon
+      $rows[$key]->show_download_icon = false;
+      if($row->allow_download != -1)
       {
-        $params->set('show_download_icon', 1);
-      }
-      else
-      {
-        if($this->_config->get('jg_download_hint'))
+        if( $row->allow_download == 1
+          || ($this->_config->get('jg_download') && $this->_config->get('jg_showfavouritesdownload')))
         {
-          $params->set('show_download_icon', -1);
+          if($this->_user->get('id') || $this->_config->get('jg_download_unreg'))
+          {
+            //$params->set('show_download_icon', 1);
+              $rows[$key]->show_download_icon = 1;
+          }
+          else
+          {
+            if($this->_config->get('jg_download_hint'))
+            {
+              //$params->set('show_download_icon', -1);
+              $rows[$key]->show_download_icon = -1;
+            }
+          }
         }
       }
     }

--- a/components/com_joomgallery/views/favourites/view.html.php
+++ b/components/com_joomgallery/views/favourites/view.html.php
@@ -139,21 +139,18 @@ class JoomGalleryViewFavourites extends JoomGalleryView
 
       // Download Icon
       $rows[$key]->show_download_icon = false;
-      if($row->allow_download != 0)
+      if(  ($row->allow_download == (-1) ? $this->_config->get('jg_download') : $row->allow_download)
+        && $this->_config->get('jg_showfavouritesdownload'))
       {
-        if( ($row->allow_download == 1 || $this->_config->get('jg_download'))
-          && $this->_config->get('jg_showfavouritesdownload'))
+        if($this->_user->get('id') || $this->_config->get('jg_download_unreg'))
         {
-          if($this->_user->get('id') || $this->_config->get('jg_download_unreg'))
+          $rows[$key]->show_download_icon = 1;
+        }
+        else
+        {
+          if($this->_config->get('jg_download_hint'))
           {
-              $rows[$key]->show_download_icon = 1;
-          }
-          else
-          {
-            if($this->_config->get('jg_download_hint'))
-            {
-              $rows[$key]->show_download_icon = -1;
-            }
+            $rows[$key]->show_download_icon = -1;
           }
         }
       }

--- a/components/com_joomgallery/views/favourites/view.html.php
+++ b/components/com_joomgallery/views/favourites/view.html.php
@@ -139,21 +139,19 @@ class JoomGalleryViewFavourites extends JoomGalleryView
 
       // Download Icon
       $rows[$key]->show_download_icon = false;
-      if($row->allow_download != -1)
+      if($row->allow_download != 0)
       {
-        if( $row->allow_download == 1
-          || ($this->_config->get('jg_download') && $this->_config->get('jg_showfavouritesdownload')))
+        if( ($row->allow_download == 1 || $this->_config->get('jg_download'))
+          && $this->_config->get('jg_showfavouritesdownload'))
         {
           if($this->_user->get('id') || $this->_config->get('jg_download_unreg'))
           {
-            //$params->set('show_download_icon', 1);
               $rows[$key]->show_download_icon = 1;
           }
           else
           {
             if($this->_config->get('jg_download_hint'))
             {
-              //$params->set('show_download_icon', -1);
               $rows[$key]->show_download_icon = -1;
             }
           }

--- a/components/com_joomgallery/views/image/view.raw.php
+++ b/components/com_joomgallery/views/image/view.raw.php
@@ -75,8 +75,7 @@ class JoomGalleryViewImage extends JoomGalleryView
         $cat_allow_download = $this->_db->loadResult();
 
         // Is the download allowed for the user group of the current user and in this category?
-        if(   $cat_allow_download == 0 
-          ||  ($cat_allow_download != 1 && !$this->_config->get('jg_download'))
+        if(   !($cat_allow_download == (-1) ? $this->_config->get('jg_download') : $cat_allow_download)
           ||  (!$this->_config->get('jg_download_unreg') && !$this->_user->get('id'))
           )
         {
@@ -112,7 +111,8 @@ class JoomGalleryViewImage extends JoomGalleryView
             ->where('a.id         = '.JRequest::getInt('id'));
         $this->_db->setQuery($query);
         $cat_allow_watermark_download = $this->_db->loadResult();
-        if($cat_allow_watermark_download == 1 || ($cat_allow_watermark_download == -1 && $this->_config->get('jg_downloadwithwatermark')))
+
+        if(($cat_allow_watermark_download == (-1) ? $this->_config->get('jg_downloadwithwatermark') : $cat_allow_watermark_download))
         {
           $include_watermark = true;
         }
@@ -166,7 +166,7 @@ class JoomGalleryViewImage extends JoomGalleryView
         $this->_db->setQuery($query);
         $cat_allow_watermark = $this->_db->loadResult();
 
-        if($cat_allow_watermark == 1 || ($cat_allow_watermark == -1 && $this->_config->get('jg_watermark')))
+        if(($cat_allow_watermark == (-1) ? $this->_config->get('jg_watermark') : $cat_allow_watermark))
         {
           $include_watermark = true;
         }

--- a/components/com_joomgallery/views/image/view.raw.php
+++ b/components/com_joomgallery/views/image/view.raw.php
@@ -64,7 +64,7 @@ class JoomGalleryViewImage extends JoomGalleryView
       // Downloading
       if($download)
       {
-        // check if dowonload is allowed
+        // check if download is allowed
         $this->_db = JFactory::getDBO();
         $query = $this->_db->getQuery(true)
             ->select('c.allow_download')
@@ -75,9 +75,9 @@ class JoomGalleryViewImage extends JoomGalleryView
         $cat_allow_download = $this->_db->loadResult();
 
         // Is the download allowed for the user group of the current user and in this category?
-        if(   $cat_allow_download != 1 
-          &&  (!$this->_config->get('jg_download')
-          ||  (!$this->_config->get('jg_download_unreg') && !$this->_user->get('id')))
+        if(   $cat_allow_download == 0 
+          ||  ($cat_allow_download != 1 && !$this->_config->get('jg_download'))
+          ||  (!$this->_config->get('jg_download_unreg') && !$this->_user->get('id'))
           )
         {
           $this->_mainframe->redirect(JRoute::_('index.php?view=gallery', false), JText::_('COM_JOOMGALLERY_COMMON_MSG_NO_ACCESS'), 'error');
@@ -112,7 +112,7 @@ class JoomGalleryViewImage extends JoomGalleryView
             ->where('a.id         = '.JRequest::getInt('id'));
         $this->_db->setQuery($query);
         $cat_allow_watermark_download = $this->_db->loadResult();
-        if($cat_allow_watermark_download == 1 || ($this->_config->get('jg_downloadwithwatermark') && $cat_allow_watermark_download == 0))
+        if($cat_allow_watermark_download == 1 || ($cat_allow_watermark_download == -1 && $this->_config->get('jg_downloadwithwatermark')))
         {
           $include_watermark = true;
         }
@@ -166,7 +166,7 @@ class JoomGalleryViewImage extends JoomGalleryView
         $this->_db->setQuery($query);
         $cat_allow_watermark = $this->_db->loadResult();
 
-        if($cat_allow_watermark == 1 || ($this->_config->get('jg_watermark') && $cat_allow_watermark == 0))
+        if($cat_allow_watermark == 1 || ($cat_allow_watermark == -1 && $this->_config->get('jg_watermark')))
         {
           $include_watermark = true;
         }

--- a/components/com_joomgallery/views/image/view.raw.php
+++ b/components/com_joomgallery/views/image/view.raw.php
@@ -64,15 +64,23 @@ class JoomGalleryViewImage extends JoomGalleryView
       // Downloading
       if($download)
       {
-        // check if download is allowed
+        // Get category settings
+        $cat_allow_download           = -1;
+        $cat_allow_watermark_download = -1;
+
         $this->_db = JFactory::getDBO();
         $query = $this->_db->getQuery(true)
-            ->select('c.allow_download')
-            ->from(_JOOM_TABLE_IMAGES.' AS a')
-            ->leftJoin(_JOOM_TABLE_CATEGORIES.' AS c ON c.cid = a.catid')
-            ->where('a.id         = '.JRequest::getInt('id'));
+              ->select('c.allow_download, c.allow_watermark_download')
+              ->from(_JOOM_TABLE_IMAGES . ' AS a')
+              ->leftJoin(_JOOM_TABLE_CATEGORIES . ' AS c ON c.cid = a.catid')
+              ->where('a.id = ' . JRequest::getInt('id'));
         $this->_db->setQuery($query);
-        $cat_allow_download = $this->_db->loadResult();
+
+        if(!empty($row = $this->_db->loadRow()))
+        {
+          $cat_allow_download           = $row[0];
+          $cat_allow_watermark_download = $row[1];
+        }
 
         // Is the download allowed for the user group of the current user and in this category?
         if(   !($cat_allow_download == (-1) ? $this->_config->get('jg_download') : $cat_allow_download)
@@ -102,16 +110,6 @@ class JoomGalleryViewImage extends JoomGalleryView
         }
 
         // Include watermark when downloading image?
-        // check category settings
-        $this->_db = JFactory::getDBO();
-        $query = $this->_db->getQuery(true)
-            ->select('c.allow_watermark_download')
-            ->from(_JOOM_TABLE_IMAGES.' AS a')
-            ->innerJoin(_JOOM_TABLE_CATEGORIES.' AS c ON c.cid = a.catid')
-            ->where('a.id         = '.JRequest::getInt('id'));
-        $this->_db->setQuery($query);
-        $cat_allow_watermark_download = $this->_db->loadResult();
-
         if(($cat_allow_watermark_download == (-1) ? $this->_config->get('jg_downloadwithwatermark') : $cat_allow_watermark_download))
         {
           $include_watermark = true;
@@ -156,13 +154,13 @@ class JoomGalleryViewImage extends JoomGalleryView
         }
 
         // Include watermark when displaying image in the detail view?
-        // check category settings
+        // Check category settings
         $this->_db = JFactory::getDBO();
         $query = $this->_db->getQuery(true)
-            ->select('c.allow_watermark')
-            ->from(_JOOM_TABLE_IMAGES.' AS a')
-            ->innerJoin(_JOOM_TABLE_CATEGORIES.' AS c ON c.cid = a.catid')
-            ->where('a.id         = '.JRequest::getInt('id'));
+              ->select('c.allow_watermark')
+              ->from(_JOOM_TABLE_IMAGES . ' AS a')
+              ->innerJoin(_JOOM_TABLE_CATEGORIES . ' AS c ON c.cid = a.catid')
+              ->where('a.id = ' . JRequest::getInt('id'));
         $this->_db->setQuery($query);
         $cat_allow_watermark = $this->_db->loadResult();
 

--- a/components/com_joomgallery/views/search/tmpl/default.php
+++ b/components/com_joomgallery/views/search/tmpl/default.php
@@ -78,11 +78,11 @@ echo $this->loadTemplate('header'); ?>
           $results = $this->_mainframe->triggerEvent('onJoomAfterDisplayThumb', array($row->id));
           echo implode('', $results) ?>
             <li>
-<?php     if($this->params->get('show_download_icon') == 1): ?>
+<?php     if($row->show_download_icon == 1): ?>
               <a href="<?php echo JRoute::_('index.php?option=com_joomgallery&task=download&id='.$row->id); ?>"<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPTEXT', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPCAPTION', true); ?>>
                 <?php echo JHTML::_('joomgallery.icon', 'download.png', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPCAPTION'); ?></a>
 <?php     endif;
-          if($this->params->get('show_download_icon') == -1): ?>
+          if($row->show_download_icon == -1): ?>
               <span<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_LOGIN_TIPTEXT', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPCAPTION', true); ?>>
                 <?php echo JHTML::_('joomgallery.icon', 'download_gr.png', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPCAPTION'); ?>
               </span>

--- a/components/com_joomgallery/views/search/view.html.php
+++ b/components/com_joomgallery/views/search/view.html.php
@@ -142,21 +142,18 @@ class JoomGalleryViewSearch extends JoomGalleryView
 
       // Show download icon for that image/category
       $rows[$key]->show_download_icon = 0;
-      if($row->allow_download != 0)
+      if(  ($row->allow_download == (-1) ? $this->_config->get('jg_download') : $row->allow_download)
+        && $this->_config->get('jg_showsearchdownload'))
       {
-        if( ($row->allow_download == 1 || $this->_config->get('jg_download'))
-          && $this->_config->get('jg_showsearchdownload'))
+        if($this->_user->get('id') || $this->_config->get('jg_download_unreg'))
         {
-          if($this->_user->get('id') || $this->_config->get('jg_download_unreg'))
+          $rows[$key]->show_download_icon = 1;
+        }
+        else
+        {
+          if($this->_config->get('jg_download_hint'))
           {
-            $rows[$key]->show_download_icon = 1;
-          }
-          else
-          {
-            if($this->_config->get('jg_download_hint'))
-            {
-              $rows[$key]->show_download_icon = -1;
-            }
+            $rows[$key]->show_download_icon = -1;
           }
         }
       }

--- a/components/com_joomgallery/views/search/view.html.php
+++ b/components/com_joomgallery/views/search/view.html.php
@@ -142,17 +142,21 @@ class JoomGalleryViewSearch extends JoomGalleryView
 
       // Show download icon for that image/category
       $rows[$key]->show_download_icon = 0;
-      if( $row->allow_download >= 0 && $this->_config->get('jg_download') && $this->_config->get('jg_showsearchdownload'))
+      if($row->allow_download != 0)
       {
-        if($this->_user->get('id') || $this->_config->get('jg_download_unreg'))
+        if( ($row->allow_download == 1 || $this->_config->get('jg_download'))
+          && $this->_config->get('jg_showsearchdownload'))
         {
-          $rows[$key]->show_download_icon = 1;
-        }
-        else
-        {
-          if($this->_config->get('jg_download_hint'))
+          if($this->_user->get('id') || $this->_config->get('jg_download_unreg'))
           {
-            $rows[$key]->show_download_icon = -1;
+            $rows[$key]->show_download_icon = 1;
+          }
+          else
+          {
+            if($this->_config->get('jg_download_hint'))
+            {
+              $rows[$key]->show_download_icon = -1;
+            }
           }
         }
       }

--- a/components/com_joomgallery/views/search/view.html.php
+++ b/components/com_joomgallery/views/search/view.html.php
@@ -139,20 +139,21 @@ class JoomGalleryViewSearch extends JoomGalleryView
           $rows[$key]->show_delete_icon = true;
         }
       }
-    }
 
-    // Download icon
-    if($this->_config->get('jg_download') && $this->_config->get('jg_showsearchdownload'))
-    {
-      if($this->_user->get('id') || $this->_config->get('jg_download_unreg'))
+      // Show download icon for that image/category
+      $rows[$key]->show_download_icon = 0;
+      if( $row->allow_download >= 0 && $this->_config->get('jg_download') && $this->_config->get('jg_showsearchdownload'))
       {
-        $params->set('show_download_icon', 1);
-      }
-      else
-      {
-        if($this->_config->get('jg_download_hint'))
+        if($this->_user->get('id') || $this->_config->get('jg_download_unreg'))
         {
-          $params->set('show_download_icon', -1);
+          $rows[$key]->show_download_icon = 1;
+        }
+        else
+        {
+          if($this->_config->get('jg_download_hint'))
+          {
+            $rows[$key]->show_download_icon = -1;
+          }
         }
       }
     }

--- a/components/com_joomgallery/views/toplist/tmpl/default.php
+++ b/components/com_joomgallery/views/toplist/tmpl/default.php
@@ -82,11 +82,11 @@ echo $this->loadTemplate('header'); ?>
           $results = $this->_mainframe->triggerEvent('onJoomAfterDisplayThumb', array($row->id));
           echo implode('', $results) ?>
             <li>
-<?php     if($this->params->get('show_download_icon') == 1): ?>
+<?php     if($row->show_download_icon == 1): ?>
               <a href="<?php echo JRoute::_('index.php?option=com_joomgallery&task=download&id='.$row->id); ?>"<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPTEXT', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPCAPTION', true); ?>>
                 <?php echo JHTML::_('joomgallery.icon', 'download.png', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPCAPTION'); ?></a>
 <?php     endif;
-          if($this->params->get('show_download_icon') == -1): ?>
+          if($row->show_download_icon == -1): ?>
               <span<?php echo JHTML::_('joomgallery.tip', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_LOGIN_TIPTEXT', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPCAPTION', true); ?>>
                 <?php echo JHTML::_('joomgallery.icon', 'download_gr.png', 'COM_JOOMGALLERY_COMMON_DOWNLOAD_TIPCAPTION'); ?>
               </span>

--- a/components/com_joomgallery/views/toplist/view.html.php
+++ b/components/com_joomgallery/views/toplist/view.html.php
@@ -207,9 +207,11 @@ class JoomGalleryViewToplist extends JoomGalleryView
         }
       }
 
-      // Download Icon
+      // Show download icon for that image/category
       $rows[$key]->show_download_icon = 0;
-      if($row->allow_download >= 0 && $this->_config->get('jg_download') && $this->_config->get('jg_showtoplistdownload'))
+      if(  $row->allow_download == 1 
+        || ($row->allow_download == -1 && $this->_config->get('jg_download'))
+        && $this->_config->get('jg_showtoplistdownload'))
       {
         if($this->_user->get('id') || $this->_config->get('jg_download_unreg'))
         {

--- a/components/com_joomgallery/views/toplist/view.html.php
+++ b/components/com_joomgallery/views/toplist/view.html.php
@@ -209,8 +209,7 @@ class JoomGalleryViewToplist extends JoomGalleryView
 
       // Show download icon for that image/category
       $rows[$key]->show_download_icon = 0;
-      if(  $row->allow_download == 1 
-        || ($row->allow_download == -1 && $this->_config->get('jg_download'))
+      if(  ($row->allow_download == (-1) ? $this->_config->get('jg_download') : $row->allow_download)
         && $this->_config->get('jg_showtoplistdownload'))
       {
         if($this->_user->get('id') || $this->_config->get('jg_download_unreg'))

--- a/components/com_joomgallery/views/toplist/view.html.php
+++ b/components/com_joomgallery/views/toplist/view.html.php
@@ -206,20 +206,21 @@ class JoomGalleryViewToplist extends JoomGalleryView
           $rows[$key]->show_delete_icon = true;
         }
       }
-    }
 
-    // Download Icon
-    if($this->_config->get('jg_download') && $this->_config->get('jg_showtoplistdownload'))
-    {
-      if($this->_user->get('id') || $this->_config->get('jg_download_unreg'))
+      // Download Icon
+      $rows[$key]->show_download_icon = 0;
+      if($row->allow_download >= 0 && $this->_config->get('jg_download') && $this->_config->get('jg_showtoplistdownload'))
       {
-        $params->set('show_download_icon', 1);
-      }
-      else
-      {
-        if($this->_config->get('jg_download_hint'))
+        if($this->_user->get('id') || $this->_config->get('jg_download_unreg'))
         {
-          $params->set('show_download_icon', -1);
+          $rows[$key]->show_download_icon = 1;
+        }
+        else
+        {
+          if($this->_config->get('jg_download_hint'))
+          {
+            $rows[$key]->show_download_icon = -1;
+          }
         }
       }
     }

--- a/language/en-GB/en-GB.com_joomgallery.ini
+++ b/language/en-GB/en-GB.com_joomgallery.ini
@@ -634,4 +634,4 @@ JYES="Yes"
 ; New or changed constants since JoomGallery 3.4.0
 ;------------------------------------------------------------------------------------
 ; New
-COM_JOOMGALLERY_COMMON_MSG_NOT_ALLOWED_DOWNLOAD_THIS_CATEGORY="Download is not allowed in this category!"
+COM_JOOMGALLERY_COMMON_MSG_NOT_ALLOWED_DOWNLOAD_IMAGE="You are not allowed to download this image"

--- a/language/en-GB/en-GB.com_joomgallery.ini
+++ b/language/en-GB/en-GB.com_joomgallery.ini
@@ -629,3 +629,9 @@ JNO="No"
 JOPTION_ORDER_FIRST="Order First"
 JOPTION_ORDER_LAST="Order Last"
 JYES="Yes"
+;
+;------------------------------------------------------------------------------------
+; New or changed constants since JoomGallery 3.4.0
+;------------------------------------------------------------------------------------
+; New
+COM_JOOMGALLERY_COMMON_MSG_NOT_ALLOWED_DOWNLOAD_THIS_CATEGORY="Download is not allowed in this category!"


### PR DESCRIPTION
DE: Erweiterte Kategorie-Einstellungen
Mit diesem Pull Request können folgende Funktionen für jede Kategorie separat eingestellt werden:
Download, Kommentare, Bewertung, Wasserzeichen (bei Anzeige), Wasserzeichen im Download.

Siehe auch die Feature-Wünsche auf uservoice:
https://joomgallery.uservoice.com/forums/13274-general/suggestions/1377077-deny-access-deny-download-deny-vote-to-categor
https://joomgallery.uservoice.com/forums/13274-joomgallery-feature-requests/suggestions/3026310-custom-download-permission-per-category
https://joomgallery.uservoice.com/forums/13274-joomgallery-feature-requests/suggestions/2916125-per-category-album-settings-for-download-passw
https://joomgallery.uservoice.com/forums/13274-joomgallery-feature-requests/suggestions/1377077-enable-or-disable-functions-for-each-category-or-i
https://joomgallery.uservoice.com/forums/13274-joomgallery-feature-requests/suggestions/3026310-custom-download-permission-per-category
https://joomgallery.uservoice.com/forums/13274-joomgallery-feature-requests/suggestions/2542229-exclude-watermark-from-selected-categories
https://joomgallery.uservoice.com/forums/13274-joomgallery-feature-requests/suggestions/4144666-enable-disable-rating-voting-per-category

Per default wird (wie bisher) die Einstellung aus dem Konfigurations-Manager genommen, diese kann dann für die jeweilige Kategorie "überschrieben" werden.

Nebenbei:
Dies ist meine letzte "Anpassung" am JoomGallery-Code. Mir ist schon klar, dass diese "Bastelarbeiten" nicht wirklich von Vorteil für die Code-Qualität sind.
Evtl. findet sie jemand trotzdem nützlich, auch wenn es nicht für eine neue Version der JoomGallery reichen wird. In letzter Zeit scheint das Projekt leider vollständig stehen geblieben zu sein. Schade, aber wohl nicht zu ändern.


EN: Extended Category Settings
With this pull request, the following functions can be set separately for each category:
Download, comments, rating, watermark (when viewing), watermarks in download
By default (as before) the setting is taken from the configuration manager, this can then be "overwritten" for the respective category.