### PR TITLE
Fix form field joomordering

### DIFF
--- a/administrator/components/com_joomgallery/models/fields/joomordering.php
+++ b/administrator/components/com_joomgallery/models/fields/joomordering.php
@@ -96,7 +96,7 @@ class JFormFieldJoomordering extends JFormField
       var originalOrder   = '.$originalOrder.';
       var originalParent  = '.$originalParent.';
       var orders          = new Array();'.$script.'
-      writeDynaList( \'class="inputbox" name="'.$this->name.'" id="'.$this->id.'"'.$disabled.' size="1"\', orders, originalParent, originalParent, originalOrder );
+      writeDynaList( \'class="inputbox" name="'.$this->name.'" id="'.$this->id.'"'.$disabled.' size="1"\', orders, originalParent, originalParent, originalOrder, document.currentScript.parentNode);
       jQuery(document).ready(function() {
         document.getElementById(\''.$parent_id.'\').addEvent(\'change\', function() {
           var catid = document.getElementById(\''.$parent_id.'\').value;


### PR DESCRIPTION
The "Ordering" form field does not work correctly anymore when editing a category in front and back end. This pull request should fix it. See also [this post.](http://www.forum.joomgallery.net/index.php/topic,6602.msg31457.html#msg31457)