### PR TITLE
Additional Fields to Frontend Form

### DIFF
--- a/administrator/components/com_joomgallery/changelog.xml
+++ b/administrator/components/com_joomgallery/changelog.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <changelog>
+  <release version="3.4" published="">
+    <entries date="20190611" modder="Lab5.ch">
+      <logentry type="#">Integrated Support for Plugin joomadditionalimagefields in the Frontend Upload Forms</logentry>
+      <logentry type="#">Little Fix : Changed attribute disabled to 'false' for field 'cid' in image.xml (in backend), because of Error onSave in Joomla! 3.9.2 and above  </logentry>
+    </entries>
+  </release>
   <release version="3.3.4" published="20180121">
     <entries date="20180121">
       <logentry type="#">Adding a modal header and footer to image selection field popup</logentry>

--- a/administrator/components/com_joomgallery/helpers/migration.php
+++ b/administrator/components/com_joomgallery/helpers/migration.php
@@ -695,7 +695,7 @@ abstract class JoomMigration
               ->select('COUNT(*)')
               ->from($table);
         $db->setQuery($query);
-
+        
         $count = $db->loadResult();
 
         if($count == 0)
@@ -1942,7 +1942,7 @@ abstract class JoomMigration
     }
     if(!isset($row->nuserip))
     {
-      $row->nuserip = '127.0.0.1';
+      $row->cmtip = '127.0.0.1';
     }
     if(!isset($row->ndate) || is_numeric($row->ndate))
     {

--- a/administrator/components/com_joomgallery/helpers/upload.php
+++ b/administrator/components/com_joomgallery/helpers/upload.php
@@ -2244,7 +2244,9 @@ class JoomUpload extends JObject
       $this->debug        = true;
       return false;
     }
-
+	 
+    $this->_mainframe->triggerEvent('onContentAfterSave', array(_JOOM_OPTION.'.registerimage', &$row, false));
+ 
     return true;
   }
 

--- a/administrator/components/com_joomgallery/includes/popup.php
+++ b/administrator/components/com_joomgallery/includes/popup.php
@@ -18,14 +18,14 @@ defined('JPATH_PLATFORM') or die;
  * @subpackage  Toolbar
  * @since       3.0
  */
-class JToolbarButtonJoomPopup extends JToolbarButton
+class JToolbarButtonPopup extends JToolbarButton
 {
 	/**
 	 * Button type
 	 *
 	 * @var    string
 	 */
-	protected $_name = 'JoomPopup';
+	protected $_name = 'Popup';
 
 	/**
 	 * Fetch the HTML for the button

--- a/administrator/components/com_joomgallery/joomgallery.xml
+++ b/administrator/components/com_joomgallery/joomgallery.xml
@@ -6,7 +6,7 @@
   <copyright>This component is released under the GNU/GPL License</copyright>
   <authorEmail>team@joomgallery.net</authorEmail>
   <authorUrl>http://www.joomgallery.net</authorUrl>
-  <version>3.3.4</version>
+  <version>3.4</version>
   <description>JoomGallery 3 is a native Joomla! 3.x gallery component</description>
   <files folder="components/com_joomgallery">
     <folder>controllers</folder>

--- a/administrator/components/com_joomgallery/models/forms/image.xml
+++ b/administrator/components/com_joomgallery/models/forms/image.xml
@@ -17,7 +17,7 @@
       label="COM_JOOMGALLERY_IMGMAN_IMAGE_ID"
       size="20"
       readonly="true"
-      disabled="true"
+      disabled="false"
     />
     <field
       name="asset_id"

--- a/administrator/components/com_joomgallery/models/image.php
+++ b/administrator/components/com_joomgallery/models/image.php
@@ -464,9 +464,7 @@ class JoomGalleryModelImage extends JoomGalleryModel
                                             $this->_config->get('jg_thumbwidth'),
                                             $this->_config->get('jg_thumbheight'),
                                             $this->_config->get('jg_thumbcreation'),
-                                            $this->_config->get('jg_thumbquality'),
-                                            false,
-                                            $this->_config->get('jg_cropposition')
+                                            $this->_config->get('jg_thumbquality')
                                             );
             break;
           case 'img':
@@ -478,8 +476,7 @@ class JoomGalleryModelImage extends JoomGalleryModel
                                             false,
                                             $this->_config->get('jg_thumbcreation'),
                                             $this->_config->get('jg_picturequality'),
-                                            true,
-                                            0
+                                            true
                                             );
             break;
           default:

--- a/administrator/components/com_joomgallery/models/maintenance.php
+++ b/administrator/components/com_joomgallery/models/maintenance.php
@@ -469,12 +469,11 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
 
     JArrayHelper::toInteger($cids);
 
-    $query = $this->_db->getQuery(true);
-
     if($refids)
     {
       // Get selected image IDs
-      $query->select('refid')
+      $query = $this->_db->getQuery(true)
+            ->select('refid')
             ->from($this->_db->qn(_JOOM_TABLE_MAINTENANCE))
             ->where('id IN ('.implode(',', $cids).')')
             ->where('type = 0');
@@ -792,6 +791,7 @@ class JoomGalleryModelMaintenance extends JoomGalleryModel
       {
         // Category deleted
         $count++;
+        $row->reorder('parent_id = '.$row->parent_id);
 
         // Delete the category in the maintenance table
         $query = $this->_db->getQuery(true)

--- a/administrator/components/com_joomgallery/views/configs/view.html.php
+++ b/administrator/components/com_joomgallery/views/configs/view.html.php
@@ -57,7 +57,7 @@ class JoomGalleryViewConfigs extends JoomGalleryView
     JToolBarHelper::title(JText::_('COM_JOOMGALLERY_CONFIGS_CONFIGURATION_MANAGER'), 'equalizer');
 
     $toolbar = JToolbar::getInstance('toolbar');
-    $toolbar->appendButton('JoomPopup', 'new', 'JTOOLBAR_NEW', 'index.php?option='._JOOM_OPTION.'&amp;controller=config&amp;layout=new&amp;tmpl=component', 400, 350, 0, 0, '', 'COM_JOOMGALLERY_CONFIGS_NEW_HEADING', 'jg-new-popup', 'new');
+    $toolbar->appendButton('Popup', 'new', 'JTOOLBAR_NEW', 'index.php?option='._JOOM_OPTION.'&amp;controller=config&amp;layout=new&amp;tmpl=component', 400, 350, 0, 0, '', 'COM_JOOMGALLERY_CONFIGS_NEW_HEADING', 'jg-new-popup', 'new');
 
     JToolbarHelper::editList('edit');
 

--- a/components/com_joomgallery/interface.php
+++ b/components/com_joomgallery/interface.php
@@ -797,7 +797,7 @@ class JoomInterface
     $return     = '';
     //$return    .= "\n".'<div class="gallerytab">'."\n";
     $return    .= '<div class="jg_row jg_row1">';
-    $rowcount   = 1;
+    $rowcount   = 0;
     $itemcount  = 0;
 
     foreach($rows as $row)

--- a/components/com_joomgallery/models/upload.php
+++ b/components/com_joomgallery/models/upload.php
@@ -33,6 +33,46 @@ class JoomGalleryModelUpload extends JoomGalleryModel
   }
 
   /**
+   * Method to allow plugins to preprocess the form
+   *
+   * @param   JForm   $form   A JForm object.
+   * @param   mixed   $data   The data expected for the form.
+   * @param   string  $group  The name of the plugin group to import (defaults to "content").
+   * @return  void
+   * @since   2.1
+   */
+  public function preprocessForm(JForm $form, $data, $group = 'content')
+  {
+	  
+
+    // Import the appropriate plugin group
+    JPluginHelper::importPlugin($group);
+
+    // Get the dispatcher
+    $dispatcher = JDispatcher::getInstance();
+
+		
+    // Trigger the form preparation event
+    $results = $dispatcher->trigger('onContentPrepareForm', array($form, $data));
+	
+
+    // Check for errors encountered while preparing the form
+    if(count($results) && in_array(false, $results, true))
+    {
+      // Get the last error
+      $error = $dispatcher->getError();
+
+      if(!($error instanceof Exception))
+      {
+        throw new Exception($error);
+      }
+    }
+  }
+
+
+
+
+  /**
    * Returns the number of images of the current user
    *
    * @return  int     The number of images of the current user

--- a/components/com_joomgallery/views/upload/tmpl/default_additional.php
+++ b/components/com_joomgallery/views/upload/tmpl/default_additional.php
@@ -1,0 +1,23 @@
+<?php defined('_JEXEC') or die('Restricted access');
+
+$i = 0;
+foreach($this->fieldSets as $name => $fieldSet):
+  if($name != ''):
+
+       echo '<h4 class="">'.$this->escape(JText::_($fieldSet->label)).'</h4>';
+      if(isset($fieldSet->description) && trim($fieldSet->description)):
+        echo '<p class="">'.$this->escape(JText::_($fieldSet->description)).'</p>';
+      endif;
+      foreach($this->form->getFieldset($name) as $field): ?>
+          <div class="control-group">
+            <div class="control-label">
+              <?php echo $field->label; ?>
+            </div>
+            <div class="controls">
+              <?php echo $field->input; ?>
+            </div>
+          </div>
+<?php endforeach;
+        echo '<hr>';
+  endif;
+endforeach;

--- a/components/com_joomgallery/views/upload/tmpl/default_ajax.php
+++ b/components/com_joomgallery/views/upload/tmpl/default_ajax.php
@@ -12,6 +12,19 @@
   </div>
 </div>
 <form action="<?php echo JRoute::_('index.php'); ?>" method="post" name="AjaxUploadForm" id="AjaxUploadForm" enctype="multipart/form-data" class="form-validate form-horizontal" onsubmit="">
+
+    <?php 
+	////////////
+	// Load Fields loaded via plugin joomadditionalimagefields
+	$this->fieldSets = $this->single_form->getFieldsets();
+    $this->assignRef('form',  $this->single_form);
+	if(count($this->fieldSets) > 0) : 
+	
+				echo $this->loadTemplate('additional'); 
+			 
+	endif; 
+	////////////
+	?>
   <div class="control-group">
     <div class="control-label">
       <?php echo $this->ajax_form->getLabel('catid'); ?>

--- a/components/com_joomgallery/views/upload/tmpl/default_batch.php
+++ b/components/com_joomgallery/views/upload/tmpl/default_batch.php
@@ -4,6 +4,20 @@
     <?php echo JText::_('COM_JOOMGALLERY_UPLOAD_BATCH_UPLOAD_NOTE'); ?>
 </div>
 <form action="<?php echo JRoute::_('index.php?type=batch'); ?>" method="post" name="BatchUploadForm" id="BatchUploadForm" enctype="multipart/form-data" class="form-validate form-horizontal" onsubmit="if(this.task.value == 'upload.upload' && !document.formvalidator.isValid(document.id('BatchUploadForm'))){alert('<?php echo JText::_('JGLOBAL_VALIDATION_FORM_FAILED', true); ?>');return false;}">
+
+    <?php 
+	////////////
+	// Load Fields loaded via plugin joomadditionalimagefields
+	$this->fieldSets = $this->single_form->getFieldsets();
+    $this->assignRef('form',  $this->single_form);
+	if(count($this->fieldSets) > 0) : 
+	
+				echo $this->loadTemplate('additional'); 
+			 
+	endif; 
+	////////////
+	?>
+
   <div class="control-group">
     <div class="control-label">
       <?php echo $this->batch_form->getLabel('catid'); ?>

--- a/components/com_joomgallery/views/upload/tmpl/default_java.php
+++ b/components/com_joomgallery/views/upload/tmpl/default_java.php
@@ -4,6 +4,20 @@
     <?php echo JText::_('COM_JOOMGALLERY_UPLOAD_JUPLOAD_NOTE'); ?>
 </div>
 <form action="<?php echo JRoute::_('index.php?type=java'); ?>" method="post" name="JavaUploadForm" id="JavaUploadForm" enctype="multipart/form-data" class="form-validate form-horizontal" onsubmit="if(this.task.value == 'upload.upload' && !document.formvalidator.isValid(document.id('JavaUploadForm'))){alert('<?php echo JText::_('JGLOBAL_VALIDATION_FORM_FAILED', true); ?>');return false;}">
+
+    <?php 
+	////////////
+	// Load Fields loaded via plugin joomadditionalimagefields
+	$this->fieldSets = $this->single_form->getFieldsets();
+    $this->assignRef('form',  $this->single_form);
+	if(count($this->fieldSets) > 0) : 
+	
+				echo $this->loadTemplate('additional'); 
+			 
+	endif; 
+	////////////
+	?>
+
   <div class="control-group">
     <div class="control-label">
       <?php echo $this->applet_form->getLabel('catid'); ?>

--- a/components/com_joomgallery/views/upload/tmpl/default_single.php
+++ b/components/com_joomgallery/views/upload/tmpl/default_single.php
@@ -1,5 +1,19 @@
 <?php defined('_JEXEC') or die('Direct Access to this location is not allowed.'); ?>
 <form action="<?php echo JRoute::_('index.php?type=single'); ?>" method="post" name="adminForm" id="SingleUploadForm" enctype="multipart/form-data" class="form-validate form-horizontal" onsubmit="if(this.task.value == 'upload.upload' && !document.formvalidator.isValid(document.id('SingleUploadForm'))){alert('<?php echo JText::_('JGLOBAL_VALIDATION_FORM_FAILED', true); ?>');return false;} return joomOnSubmit();">
+
+    <?php 
+	////////////
+	// Load Fields loaded via plugin joomadditionalimagefields
+	$this->fieldSets = $this->single_form->getFieldsets();
+    $this->assignRef('form',  $this->single_form);
+	if(count($this->fieldSets) > 0) : 
+	
+				echo $this->loadTemplate('additional'); 
+			 
+	endif; 
+	////////////
+	?>
+
   <div class="control-group">
     <div class="control-label">
       <?php echo $this->single_form->getLabel('catid'); ?>

--- a/components/com_joomgallery/views/upload/view.html.php
+++ b/components/com_joomgallery/views/upload/view.html.php
@@ -146,12 +146,20 @@ class JoomGalleryViewUpload extends JoomGalleryView
       $this->uploads[key($this->uploads)]['active'] = true;
     }
 
+	$model = $this->getModel();
+	
     JForm::addFormPath(JPATH_COMPONENT.'/models/forms');
     $this->single_form  = JForm::getInstance(_JOOM_OPTION.'.upload', 'upload');
     $this->ajax_form    = JForm::getInstance(_JOOM_OPTION.'.ajaxupload', 'ajaxupload');
     $this->batch_form   = JForm::getInstance(_JOOM_OPTION.'.batchupload', 'batchupload');
     $this->applet_form  = JForm::getInstance(_JOOM_OPTION.'.jupload', 'jupload');
     $this->single_form->setFieldAttribute('arrscreenshot', 'quantity', $inputcounter);
+	
+    $model->preprocessForm($this->single_form, null);
+    $model->preprocessForm($this->ajax_form, null);
+    $model->preprocessForm($this->batch_form, null);
+    $model->preprocessForm($this->applet_form, null);
+	
 
     $this->_doc->addScriptDeclaration('    var jg_filenamewithjs = '.($this->_config->get('jg_filenamewithjs') ? 'true' : 'false').';');
     $this->_doc->addScript($this->_ambit->getScript('upload.js'));

--- a/joomgallery.xml
+++ b/joomgallery.xml
@@ -6,7 +6,7 @@
   <copyright>This component is released under the GNU/GPL License</copyright>
   <authorEmail>team@joomgallery.net</authorEmail>
   <authorUrl>http://www.joomgallery.net</authorUrl>
-  <version>3.3.4</version>
+  <version>3.4</version>
   <description>JoomGallery 3 is a native Joomla! 3.x gallery component</description>
   <files folder="components/com_joomgallery">
     <folder>controllers</folder>

--- a/media/joomgallery/css/admin.joomgallery.css
+++ b/media/joomgallery/css/admin.joomgallery.css
@@ -245,9 +245,6 @@ label#rules-lbl {
 #jg-new-popup .chzn-container{
   margin-left:100px;
 }
-#jg-new-popup #formNew{
-  margin: 0px;
-}
 
 /* Edit images view: Space between boxes */
 #jg_movecopy{


### PR DESCRIPTION
I developed JoomGallery further, to finally make it possible to easily have the Additional Image Fields ready to use directly in the frontend forms when uploading images.

( Note : You'll still need to additionally install the Plugin "JoomAdditionalImageFields" for you to make use of that feature in your JoomGallery installation. If you don't, it doesnt affect you.
Note2: I also updated the "JoomAdditionalImageFields" accordingly - You'll need to use that new version together with this update, if you want the Additional Image Fileds be available in frontend forms ).